### PR TITLE
Add geonames configuration for questioning_authority functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Donut is a Hydra head based on [Hyrax](http://github.com/projecthydra-labs/hyrax
 * [Redis](http://redis.io/)
     * Start Redis with `redis-server`
 * [Local authentication configuration](https://github.com/nulib/donut/wiki/Authentication-setup-for-dev-environment)
+* [Geonames user registration](http://www.geonames.org/manageaccount)
+    * For local development, add the registered user to `settings.local.yml` with the `geonames_username` key, e.g. `geonames_username: geonames_test_user`
 
 ## Initial Setup
 

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -85,7 +85,7 @@ Hyrax.config do |config|
 
   # Location autocomplete uses geonames to search for named regions
   # Username for connecting to geonames
-  # config.geonames_username = ''
+  config.geonames_username = Settings.geonames_username
 
   # Should the acceptance of the licence agreement be active (checkbox), or
   # implied when the save button is pressed? Set to true for active

--- a/config/oclcts-authorities.yml
+++ b/config/oclcts-authorities.yml
@@ -1,0 +1,24 @@
+url-pattern:
+  prefix-query: http://tspilot.oclc.org/{authority-id}/?query=oclcts.rootHeading+exact+%22{query}*%22&version=1.1&operation=searchRetrieve&recordSchema=http%3A%2F%2Fzthes.z3950.org%2Fxml%2F1.0%2F&maximumRecords=10&startRecord=1&resultSetTTL=300&recordPacking=xml&recordXPath=&sortKeys=
+  id-lookup: http://tspilot.oclc.org/{authority-id}/?query=dc.identifier+exact+%22{id}%22&version=1.1&operation=searchRetrieve&recordSchema=http%3A%2F%2Fzthes.z3950.org%2Fxml%2F1.0%2F&maximumRecords=10&startRecord=1&resultSetTTL=300&recordPacking=xml&recordXPath=&sortKeys=
+authorities:
+  lcgft:
+    name: Library of Congress Genre/Form Terms for Library and Archival Materials (LCGFT)
+  bisacsh:
+    name: Book Industry Study Group Subject Headings (BISAC®). Used with permission.
+  fast:
+    name: Faceted Application of Subject Terminology (FAST subject headings)
+  gsafd:
+    name: Form and genre headings for fiction and drama
+  lcshac:
+    name: Library of Congress AC Subject Headings
+  lcsh:
+    name: Library of Congress Subject Headings
+  mesh:
+    name: Medical Subject Headings (MeSH®)
+  lctgm:
+    name: "Thesaurus for graphic materials: TGM I, Subject terms"
+  gmgpc:
+    name: "Thesaurus for graphic materials: TGM II, Genre terms"
+  meta:
+    name: Controlled Vocabulary Metadata

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,3 +18,4 @@ solr:
     snitch:
 zookeeper:
   connection_str: "localhost:9983/configs"
+geonames_username: ''


### PR DESCRIPTION
For local development, add a registered geonames user to `settings.local.yml` with the `geonames_username` key, e.g. `geonames_username: geonames_test_user`. This is just a configuration for built-in Hyrax functionality in web forms using `questioning_authority` functionality that relies upon the Geonames service, e.g. the `Location` field in the Images work type.

Note: the user must have the "free web service" option enabled from http://www.geonames.org/manageaccount