### PR TITLE
Add ark minting for Image works

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'hyrax', github: 'samvera/hyrax', branch: 'master'
 gem 'nulib_microservices', github: 'nulib/nulib_microservices'
 
 gem 'config'
+gem 'ezid-client'
 gem 'hydra-role-management'
 gem 'omniauth-openam'
 gem 'pul_uv_rails', github: 'pulibrary/pul_uv_rails', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,8 @@ GEM
     ethon (0.10.1)
       ffi (>= 1.3.0)
     execjs (2.7.0)
+    ezid-client (1.7.1)
+      hashie (~> 3.4, >= 3.4.3)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.8.0)
@@ -826,6 +828,7 @@ DEPENDENCIES
   database_cleaner
   devise
   devise-guests (~> 0.6)
+  ezid-client
   factory_girl_rails
   fcrepo_wrapper
   hydra-role-management
@@ -860,4 +863,4 @@ DEPENDENCIES
   zk
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -12,6 +12,10 @@ class Image < ActiveFedora::Base
 
   self.human_readable_type = 'Image'
 
+  after_save do
+    ArkMintingService.mint_identifier_for(self) if ark.nil?
+  end
+
   property :abstract, predicate: ::RDF::Vocab::DC.abstract, multiple: true do |index|
     index.as :stored_searchable
   end
@@ -21,6 +25,10 @@ class Image < ActiveFedora::Base
   end
 
   property :accession_number, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/subjectSchemes/local'), multiple: false do |index|
+    index.as :stored_searchable
+  end
+
+  property :ark, predicate: ::RDF::Vocab::DataCite.ark, multiple: false do |index|
     index.as :stored_searchable
   end
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -38,6 +38,10 @@ class SolrDocument
     fetch(Solrizer.solr_name('alternate_title', :stored_searchable), [])
   end
 
+  def ark
+    fetch(Solrizer.solr_name('ark', :stored_searchable), [])
+  end
+
   def call_number
     fetch(Solrizer.solr_name('call_number', :stored_searchable), [])
   end

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -2,7 +2,7 @@
 #  `rails generate hyrax:work Image`
 module Hyrax
   class ImagePresenter < Hyrax::WorkShowPresenter
-    delegate :abstract, :accession_number, :alternate_title, :call_number, :caption, :catalog_key, :citation, :contributor_role, :creator_role, :genre, :provenance, :physical_description, :related_url_label, :rights_holder, :style_period, :technique, to: :solr_document # rubocop:disable Metrics/LineLength
+    delegate :abstract, :accession_number, :alternate_title, :ark, :call_number, :caption, :catalog_key, :citation, :contributor_role, :creator_role, :genre, :provenance, :physical_description, :related_url_label, :rights_holder, :style_period, :technique, to: :solr_document # rubocop:disable Metrics/LineLength
 
     Hyrax::MemberPresenterFactory.file_presenter_class = ::FileSetPresenter
 

--- a/app/services/ark_minting_service.rb
+++ b/app/services/ark_minting_service.rb
@@ -1,0 +1,116 @@
+class ArkMintingService
+  include Rails.application.routes.url_helpers
+  include ActionDispatch::Routing::PolymorphicRoutes
+
+  attr_reader :work
+
+  def self.mint_identifier_for(work)
+    ArkMintingService.new(work).run
+  end
+
+  def initialize(obj)
+    @work = obj
+  end
+
+  def run
+    return unless identifier_server_reachable?
+    if work.ark.present?
+      update_metadata
+    else
+      mint_ark
+    end
+  end
+
+  private
+
+    def update_metadata
+      return if minter_user == 'apitest'
+      minter.modify(work.ark, metadata)
+    end
+
+    def mint_ark
+      work.ark = minter.mint(metadata).id
+      work.save
+    end
+
+    def minter_user
+      Ezid::Client.config.user
+    end
+
+    def minter
+      Ezid::Identifier
+    end
+
+    # Any error raised during connection is considered false
+    def identifier_server_reachable?
+      Ezid::Client.new.server_status.up?
+    rescue
+      false
+    end
+
+    def metadata
+      {
+        'datacite.creator' => creator,
+        'datacite.title' => title,
+        'datacite.publisher' => publisher,
+        'datacite.publicationyear' => date_created,
+        'datacite.resourcetype' => resource_type,
+        target: url
+      }
+    end
+
+    def creator
+      return 'Unknown' if work.creator.empty?
+      work.creator.join('; ')
+    end
+
+    def title
+      return 'Unknown' if work.title.empty?
+      work.title.join('; ')
+    end
+
+    def publisher
+      return 'Unknown' if work.publisher.empty?
+      work.publisher.join('; ')
+    end
+
+    def date_created
+      return 'Unknown' if work.date_created.empty?
+      work.date_created.join('; ')
+    end
+
+    # We need to map the available options in the resource_types.yml file to what ezid expects.
+    # rubocop:disable Metrics/MethodLength
+    def ezid_map
+      {
+        'Audio' =>          'Sound',
+        'Book' =>           'Text',
+        'Dataset' =>        'Dataset',
+        'Dissertation' =>   'Text',
+        'Image' =>          'Image',
+        'Article' =>        'Text',
+        'Masters Thesis' => 'Text',
+        'Part of Book' =>   'Text',
+        'Poster' =>         'Text',
+        'Project' =>        'Other',
+        'Report' =>         'Text',
+        'Research Paper' => 'Text',
+        'Video' =>          'Audiovisual',
+        'Other' =>          'Other'
+      }
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def resource_type
+      return 'Other' if work.resource_type.empty?
+      # Switch out the hyrax types for ezid approved ones.
+      types = work.resource_type.map { |x| ezid_map.fetch(x) }
+      # EZID can only accomodate a single resource type for an ARK, but hyrax can support many
+      # so as a workaround we'll just send the first one
+      types.first
+    end
+
+    def url
+      polymorphic_url(work, host: Rails.application.secrets.host || 'localhost:3000')
+    end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,5 +1,6 @@
 <%= presenter.attribute_to_html(:abstract) %>
 <%= presenter.attribute_to_html(:accession_number) %>
+<%= presenter.attribute_to_html(:ark, label: 'ARK') %>
 <%= presenter.attribute_to_html(:based_near_label) %>
 <%= presenter.attribute_to_html(:call_number) %>
 <%= presenter.attribute_to_html(:caption) %>

--- a/config/initializers/ezid_credentials.rb
+++ b/config/initializers/ezid_credentials.rb
@@ -1,0 +1,16 @@
+# prod
+# EZID_DEFAULT_SHOULDER: ark:21985/N2
+# EZID_USER: user
+# EZID_PASSWORD: password
+# EZID_HOST: ezid.lib.purdue.edu\
+# EZID_PORT: 443
+# EZID_USE_SSL: true
+
+Ezid::Client.configure do |conf|
+  conf.default_shoulder = 'ark:/99999/fk4' unless ENV['EZID_DEFAULT_SHOULDER']
+  conf.user = 'apitest' unless ENV['EZID_USER']
+  conf.password = 'apitest' unless ENV['EZID_PASSWORD']
+  conf.host = 'ezid.lib.purdue.edu' unless ENV['EZID_HOST']
+  conf.port = 443 unless ENV['EZID_PORT']
+  conf.use_ssl = true unless ENV['EZID_USE_SSL']
+end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -5,8 +5,9 @@ FactoryGirl.define do
     rights_statement ['http://rightsstatements.org/vocab/NKC/1.0/']
     description ['Test description']
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-    abstract ['Lemon drops donut gummi bears carrot cake dragée.']
+    abstract ['Lemon drops donut gummi bears carrot cake.']
     accession_number 'Lgf0825'
+    ark 'ark:/12345/12345'
     call_number 'W107.8:Am6'
     caption ['This is the caption seen on the image']
     catalog_key ['9943338434202441']

--- a/spec/forms/hyrax/image_form_spec.rb
+++ b/spec/forms/hyrax/image_form_spec.rb
@@ -11,8 +11,12 @@ RSpec.describe Hyrax::ImageForm do
   describe '::terms' do
     subject { form.terms }
 
-    it do
+    it 'contains fields that users should are allowed to edit' do
       is_expected.to include(:resource_type, :abstract, :accession_number, :call_number, :caption, :catalog_key, :citation, :contributor_role, :creator_role, :genre, :provenance, :physical_description, :related_url_label, :rights_holder, :style_period, :technique)
+    end
+
+    it 'does not contain fields that users should not be allowed to edit' do
+      is_expected.not_to include(:ark)
     end
   end
 

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Image do
   it { is_expected.to respond_to(:accession_number) }
   it { is_expected.to respond_to(:abstract) }
   it { is_expected.to respond_to(:alternate_title) }
+  it { is_expected.to respond_to(:ark) }
   it { is_expected.to respond_to(:call_number) }
   it { is_expected.to respond_to(:caption) }
   it { is_expected.to respond_to(:catalog_key) }

--- a/spec/presenters/hyrax/image_presenter_spec.rb
+++ b/spec/presenters/hyrax/image_presenter_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe Hyrax::ImagePresenter, type: :unit do
   it { expect(presenter.alternate_title).to eq ['Alternate Title 1'] }
   it { expect(presenter.rights_statement).to eq ['http://rightsstatements.org/vocab/NKC/1.0/'] }
   it { expect(presenter.description).to eq ['Test description'] }
-  it { expect(presenter.abstract).to eq ['Lemon drops donut gummi bears carrot cake dragée.'] }
+  it { expect(presenter.abstract).to eq ['Lemon drops donut gummi bears carrot cake.'] }
   it { expect(presenter.accession_number).to eq ['Lgf0825'] }
+  it { expect(presenter.ark).to eq ['ark:/12345/12345'] }
   it { expect(presenter.call_number).to eq ['W107.8:Am6'] }
   it { expect(presenter.caption).to eq ['This is the caption seen on the image'] }
   it { expect(presenter.catalog_key).to eq ['9943338434202441'] }


### PR DESCRIPTION
Adds ARK minting support for Image works using an `after_save` callback.

Production environment needs to set the following ENV variables: `EZID_DEFAULT_SHOULDER, EZID_USER, EZID_PASSWORD, EZID_HOST, EZID_PORT, EZID_USE_SSL`

`ezid-client` added to the Gemfile, make sure to run `bundle install` locally.