### PR TITLE
remove accession number from required fields

### DIFF
--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class ImageForm < Hyrax::Forms::WorkForm
     self.model_class = ::Image
     self.terms += [:alternate_title, :resource_type, :abstract, :accession_number, :call_number, :caption, :catalog_key, :citation, :contributor_role, :creator_role, :genre, :provenance, :physical_description, :related_url_label, :rights_holder, :style_period, :technique] # rubocop:disable Metrics/LineLength
-    self.required_fields = [:title, :date_created, :accession_number, :rights_statement]
+    self.required_fields = [:title, :date_created, :rights_statement]
 
     def primary_terms
       [:title, :date_created, :accession_number, :creator, :rights_statement, :description]

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -8,7 +8,6 @@ class Image < ActiveFedora::Base
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
-  validates :accession_number, presence: { message: 'Your work must have an accession_number.' }
 
   self.human_readable_type = 'Image'
 

--- a/spec/forms/hyrax/image_form_spec.rb
+++ b/spec/forms/hyrax/image_form_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hyrax::ImageForm do
     subject { form.required_fields }
 
     it do
-      is_expected.to contain_exactly(:title, :date_created, :accession_number, :rights_statement)
+      is_expected.to contain_exactly(:title, :date_created, :rights_statement)
     end
   end
 


### PR DESCRIPTION
Fixes: https://github.com/nulib/next-generation-repository/issues/216

batch upload form just includes the default fields.