### PR TITLE
Remove param and green up csv_importer_spec

### DIFF
--- a/config/initializers/aws-sdk.rb
+++ b/config/initializers/aws-sdk.rb
@@ -1,0 +1,8 @@
+require 'aws-sdk'
+
+if Settings.aws.endpoint.present?
+  Aws.config.update(
+    endpoint: Settings.aws.endpoint,
+    force_path_style: true
+  )
+end

--- a/lib/importer/csv_importer.rb
+++ b/lib/importer/csv_importer.rb
@@ -5,12 +5,9 @@ module Importer
   class CSVImporter
     # @param [String] CSV contents
     # @param [Aws::S3::Bucket] S3 Bucket, passed to factory constructor
-    # @param [#to_s, Class] model if Class, the factory class to be invoked per row.
-    # Otherwise, the stringable first (Xxx) portion of an "XxxFactory" constant.
-    def initialize(csv, s3_resource, model = nil)
+    def initialize(csv, s3_resource)
       @csv = csv
       @s3_resource = s3_resource
-      @model = model
     end
 
     # @return [Integer] count of objects created
@@ -24,6 +21,7 @@ module Importer
     end
 
     private
+
       def parser
         CSVParser.new(@csv)
       end
@@ -44,7 +42,7 @@ module Importer
       # @option attributes [String] :type overrides model for a single object
       # @note remaining attributes are passed to factory constructor
       def create_fedora_objects(attributes)
-        factory_class(attributes.delete(:type) || @model).new(attributes, @s3_resource).run
+        factory_class(attributes.delete(:type)).new(attributes, @s3_resource).run
       end
   end
 end


### PR DESCRIPTION
- Removes @model parameter from Importer::CSVImporter#initialize
- Refactors Importer::CSVImporter spec to use aws-sdk functionality