### PR TITLE
Refactor csv_parser_spec to read csv file and update specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ Metrics/BlockLength:
     - 'config/routes.rb'
     - 'config/initializers/simple_form_bootstrap.rb'
     - 'spec/factories/images.rb'
+    - 'spec/lib/importer/csv_parser_spec.rb'
 
 Metrics/ClassLength:
   Exclude:

--- a/spec/lib/importer/csv_parser_spec.rb
+++ b/spec/lib/importer/csv_parser_spec.rb
@@ -3,63 +3,71 @@ require 'rails_helper'
 require 'importer'
 
 RSpec.describe Importer::CSVParser do
-  let(:parser) { described_class.new(file) }
+  let(:parser) { described_class.new(File.read(file)) }
   let(:attributes) { parser.attributes }
   let(:file) { "#{fixture_path}/csv/sample.csv" }
   let(:first_record) { parser.first }
 
   context 'Importing just images' do
+    # rubocop:disable RSpec/ExampleLength
     it 'parses a record' do
       # Title must be singular
-      expect(first_record[:title]).to eq ['Work in Progress - A Framework for Building Interactive Learning Modules']
-
-      expect(first_record[:file]).to eq ['DalmonEtAl2011_Framework_Final.pdf']
-
-      expect(first_record[:date_created]).to eq ['2011']
-
-      expect(first_record[:contributor]).to eq [{ name: ["Dalmon, Danilo"] },
-                                                { name: ["Brandao, Leonidas"] },
-                                                { name: ["Brandao, Anarosa"] },
-                                                { name: ["Isotani, Seiji"] }]
+      expect(first_record[:title]).to eq [
+        'Knowing their lines: how social boundaries undermine equity-based integration policies in United States and South African schools'
+      ]
+      expect(first_record[:file]).to contain_exactly('files/coffee.jpg', 'files/nul.jpg')
+      expect(first_record[:date_created]).to contain_exactly('2009-12')
+      expect(first_record[:contributor]).to contain_exactly(
+        a_hash_including(name: ['Carter, Prudence L.']),
+        a_hash_including(name: ['Caruthers, Jakeya']),
+        a_hash_including(name: ['Perspectives in Education'])
+      )
       expect(first_record.keys).to match_array [:id, :type, :title, :description,
                                                 :subject, :resource_type, :contributor,
-                                                :date_created, :file]
+                                                :date_created, :file, :collection]
     end
+    # rubocop:enable RSpec/ExampleLength
   end
 
   describe 'validating CSV headers' do
-    subject { parser.send(:validate_headers, headers) }
+    subject(:parsed_headers) { parser.send(:validate_headers, headers) }
 
     context 'with valid headers' do
-      let(:headers) { %w(id title) }
-      it { is_expected.to eq headers }
+      let(:headers) { %w[id title] }
+
+      it 'contains the correct headers' do
+        expect(parsed_headers).to eq headers
+      end
     end
 
     context 'with invalid headers' do
       let(:headers) { ['something bad', 'title'] }
 
       it 'raises an error' do
-        expect { subject }.to raise_error 'Invalid headers: something bad'
+        expect { parsed_headers }.to raise_error(RuntimeError, 'Invalid headers: something bad')
       end
     end
 
     context 'with nil headers' do
       let(:headers) { ['title', nil] }
+
       it { is_expected.to eq headers }
     end
 
     # It doesn't expect a matching column for "resource_type"
     context 'with resource_type column' do
-      let(:headers) { %w(resource_type title) }
+      let(:headers) { %w[resource_type title] }
+
       it { is_expected.to eq headers }
     end
   end
 
-  describe "validate_header_pairs" do
-    subject { parser.send(:validate_header_pairs, headers) }
+  describe 'validate_header_pairs' do
+    subject(:parsed_headers) { parser.send(:validate_header_pairs, headers) }
 
     context 'with "*_type" columns' do
-      let(:headers) { %w(rights_holder rights_holder_type rights_holder title note_type note) }
+      let(:headers) { %w[rights_holder rights_holder_type rights_holder title note_type note] }
+
       it { is_expected.to be_nil }
     end
 
@@ -68,13 +76,13 @@ RSpec.describe Importer::CSVParser do
     # authority.  If the columns aren't in the correct order,
     # raise an error.
     context 'with columns in the wrong order' do
-      let(:headers) { %w(note note_type rights_holder_type rights_holder_type rights_holder title) }
+      let(:headers) { %w[note note_type rights_holder_type rights_holder_type rights_holder title] }
 
       it 'raises an error' do
-        expect { subject }.to raise_error "Invalid headers: 'note_type' column " \
+        expect { parsed_headers }.to raise_error(RuntimeError, "Invalid headers: 'note_type' column " \
           "must be immediately followed by 'note' column., Invalid headers: " \
           "'rights_holder_type' column must be immediately followed by " \
-          "'rights_holder' column."
+          "'rights_holder' column.")
       end
     end
   end


### PR DESCRIPTION
Not much to add beyond PR title. I'm not a big fan of having to add `rubocop:disable RSpec/ExampleLength` to `spec/lib/importer/csv_parser_spec.rb:13` but it's not a difficult refactor in the near future.