### PR TITLE
handle s3 credentials for dev and test in app; automatically setup an…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ Metrics/BlockLength:
     - 'spec/factories/images.rb'
     - 'spec/lib/importer/factory/image_factory_spec.rb'
     - 'spec/lib/importer/csv_parser_spec.rb'
+    - 'lib/tasks/s3_tasks.rake'
 
 Metrics/ClassLength:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 
 before_install:
   - 'docker pull minio/minio'
-  - 'docker run -d -v ${TRAVIS_BUILD_DIR}/spec/fixtures/minio:/data -p 127.0.0.1:9000:9000 -e "MINIO_ACCESS_KEY=travis-build-key" -e "MINIO_SECRET_KEY=travis-build-secret" minio/minio server /data'
+  - 'docker run -d -p 127.0.0.1:9000:9000 -e "MINIO_ACCESS_KEY=travis-build-key" -e "MINIO_SECRET_KEY=travis-build-secret" minio/minio server /data'
   - 'gem update bundler'
 
 env:

--- a/README.md
+++ b/README.md
@@ -33,46 +33,11 @@ Donut is a Hydra head based on [Hyrax](http://github.com/projecthydra-labs/hyrax
 To pull minio and stand it up, assuming you have docker installed:
 
 * `docker pull minio/minio`
-* `docker run -p 9000:9000 -e "MINIO_ACCESS_KEY=test-1234" -e "MINIO_SECRET_KEY=test-1234" minio/minio server ./data`
+* `docker run -p 9000:9000 -e "MINIO_ACCESS_KEY=travis-build-key" -e "MINIO_SECRET_KEY=travis-build-secret" minio/minio server ./data`
 
-### Create a bucket in minio
+### Create and populate bucket in minio
 
-The following command uses `aws s3api` to create a bucket named `test-1234`
-
-```shell
-aws --profile minio --endpoint-url http://localhost:9000 s3api create-bucket --bucket test-1234 --region us-east-1
-```
-
-### Copying fixture data to minio
-
-The following command uses `aws s3` to copy the contents of `spec/fixtures/csv` recursively to a minio bucket named `test-1234`
-
-```shell
-aws --profile minio --endpoint-url http://localhost:9000 s3 cp spec/fixtures/csv s3://test-1234 --recursive --exclude ".DS_Store"
-```
-
-## AWS-CLI
-
-Update `~/.aws/credentials`
-
-```
-[minio]
-aws_access_key_id=test-1234
-aws_secret_access_key=test-1234
-```
-
-Update `~/.aws/config`
-
-```
-[profile minio]
-region=us-east-1
-```
-
-Export AWS_PROFILE environment variable with the `minio` profile, so the application can pick up the configuration.
-
-```shell
-export AWS_PROFILE=minio
-```
+just run `bundle exec rake s3:setup` , that creates a new bucket and populates it with our fixtures
 
 ## Running the Tests
 

--- a/config/initializers/aws_sdk.rb
+++ b/config/initializers/aws_sdk.rb
@@ -3,6 +3,8 @@ require 'aws-sdk'
 if Settings.aws.endpoint.present?
   Aws.config.update(
     endpoint: Settings.aws.endpoint,
+    region: Settings.aws.region,
+    credentials: Aws::Credentials.new(Settings.aws.aws_access_key_id, Settings.aws.aws_secret_key_id),
     force_path_style: true
   )
 end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,6 @@
 aws:
   endpoint: http://127.0.0.1:9000
+  region: us-east-1
+  aws_access_key_id: travis-build-key
+  aws_secret_key_id: travis-build-secret
+  bucket: development-bucket

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,6 @@
 aws:
   endpoint: http://127.0.0.1:9000
+  region: us-east-1
+  aws_access_key_id: travis-build-key
+  aws_secret_key_id: travis-build-secret
+  bucket: test-bucket

--- a/lib/tasks/s3_tasks.rake
+++ b/lib/tasks/s3_tasks.rake
@@ -1,0 +1,44 @@
+
+namespace :s3 do
+  desc 'Generate S3 bucket for dev/staging'
+  task generate_bucket: :environment do
+    Aws::S3::Client.new.create_bucket(bucket: Settings.aws.bucket)
+  end
+
+  desc 'populate s3 buckets with test data'
+  task populate_bucket: :environment do
+    s3 = Aws::S3::Resource.new
+    Dir.chdir('spec/fixtures/csv')
+    Dir.glob('**/*').each do |file|
+      next if File.directory?(file)
+      obj = s3.bucket(Settings.aws.bucket).object(file)
+      obj.upload_file(file)
+    end
+  end
+
+  desc 'create and populate a s3 bucket with test data'
+  task :setup do
+    Rake::Task['s3:generate_bucket'].invoke
+    Rake::Task['s3:populate_bucket'].invoke
+  end
+
+  desc 'removes files from s3 bucket'
+  task empty_bucket: :environment do
+    client = Aws::S3::Client.new
+    objs = client.list_objects_v2(bucket: Settings.aws.bucket)
+    objs.contents.each do |obj|
+      client.delete_object(bucket: Settings.aws.bucket, key: obj.key)
+    end
+  end
+
+  desc 'deletes an empty bucket'
+  task delete_bucket: :environment do
+    Aws::S3::Client.new.delete_bucket(bucket: Settings.aws.bucket)
+  end
+
+  desc 'empties and deletes the test bucket'
+  task :teardown do
+    Rake::Task['s3:empty_bucket'].invoke
+    Rake::Task['s3:delete_bucket'].invoke
+  end
+end

--- a/spec/lib/importer/csv_importer_spec.rb
+++ b/spec/lib/importer/csv_importer_spec.rb
@@ -3,7 +3,7 @@ require 'importer'
 require 'aws-sdk'
 
 RSpec.describe Importer::CSVImporter do
-  let(:bucket) { 'buckett' }
+  let(:bucket) { Settings.aws.bucket }
   let(:csv_file_key) { 'sample.csv' }
   let(:csv) { Aws::S3::Client.new.get_object(bucket: bucket, key: csv_file_key).body.read }
   let(:csv_resource) { Aws::S3::Object.new(client: Aws::S3::Client.new, bucket_name: bucket, key: csv_file_key) }

--- a/spec/lib/importer/factory/image_factory_spec.rb
+++ b/spec/lib/importer/factory/image_factory_spec.rb
@@ -4,7 +4,7 @@ require 'importer'
 RSpec.describe Importer::Factory::ImageFactory, :clean do
   let(:factory) { described_class.new(attributes) }
   let(:actor) { instance_spy('actor') }
-  let(:bucket) { 'buckett' }
+  let(:bucket) { Settings.aws.bucket }
   let(:csv_file_key) { 'sample.csv' }
   let(:csv_resource) { Aws::S3::Object.new(client: Aws::S3::Client.new, bucket_name: bucket, key: csv_file_key) }
   let(:attributes) do
@@ -29,7 +29,7 @@ RSpec.describe Importer::Factory::ImageFactory, :clean do
         factory.run
         expect(actor).to have_received(:create).with(Hyrax::Actors::Environment) do |k|
           expect(k.attributes).to include(member_of_collections: [coll])
-          expect(k.attributes[:remote_files].first[:url]).to include('/buckett/files/coffee.jpg')
+          expect(k.attributes[:remote_files].first[:url]).to include("#{Settings.aws.bucket}/files/coffee.jpg")
         end
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe Importer::Factory::ImageFactory, :clean do
         factory.run
         expect(actor).to have_received(:update).with(Hyrax::Actors::Environment) do |k|
           expect(k.attributes).to include(member_of_collections: [coll])
-          expect(k.attributes[:remote_files].first[:url]).to include('/buckett/files/coffee.jpg')
+          expect(k.attributes[:remote_files].first[:url]).to include("#{Settings.aws.bucket}/files/coffee.jpg")
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'rake'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -62,6 +63,18 @@ RSpec.configure do |config|
 
   config.before(:each, type: :feature) do
     Warden.test_mode!
+  end
+
+  config.before(:suite) do
+    Rake.application.rake_require 'tasks/s3_tasks'
+    Rake::Task.define_task(:environment)
+    Rake::Task['s3:setup'].invoke
+  end
+
+  config.after(:suite) do
+    Rake.application.rake_require 'tasks/s3_tasks'
+    Rake::Task.define_task(:environment)
+    Rake::Task['s3:teardown'].invoke
   end
 
   config.after(:each, type: :feature) do


### PR DESCRIPTION
…d teardown fixtures for tests

so with these changes we don't have to run a bunch of the tasks that are in master branch's README. You just need to have minio running in docker and you can run `rake s3:setup` to create a bucket and populate it and `rake s3:teardown` to clean it out. 

The tests now also create their own bucket and populate it before the test suite is run too