### PR TITLE
unencoding an encoded url

### DIFF
--- a/lib/importer/factory/object_factory.rb
+++ b/lib/importer/factory/object_factory.rb
@@ -120,6 +120,11 @@ module Importer
         def file_spec(file_path)
           s3_object = resolve_file(file_path)
           url = s3_object.presigned_url(:get)
+          # Line 124 is ugly and very hacky, but it's much easier for us to change our scripts than upstream hyrax
+          # Hyrax encodes the URL here https://github.com/samvera/hyrax/blob/4fd8d9ad3c32db7deffc3b5246af5d1459a4b046/app/actors/hyrax/actors/create_with_remote_files_actor.rb#L53
+          # but the presigned url we get above is already encoded. So we're unencoding it here before we sent it to
+          # hyrax, where it will get encoded again. Not pretty, but it works
+          url = Addressable::URI.unencode(url)
           { url: url, file_size: s3_object.size }
         end
 


### PR DESCRIPTION
fixes #77 

so here's a deceptively simple fix to a weird issue. Basically the AWS gem's presigned url call returns an encoded URL, but later on in the actor stack in hyrax the url gets encoded again and messes with the url and it no longer resolves. 

The proper, long term fix would be to handle both encoded and non-encoded urls in hyrax, but that would require more time and work. 

So for right now i just decode the url and pass it along the actor stack, which seems to work fine.