### PR TITLE
more detailed logging to help debugging

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-staging = false
+staging = true
 if ENV['STAGING_ENV'].present?
   require 'listen'
   require 'web_console'


### PR DESCRIPTION
the logs on AWS are pretty sparse, changing this setting changes the log level to debug so hopefully we can see more detail and notice if anything is off. 

This shouldn't be a permanent change, only to assist us in figuring out why derivative generation isn't happening on AWS but works locally 