### PR TITLE
Administrative metadata

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,7 @@ Metrics/BlockLength:
     - 'spec/lib/importer/factory/image_factory_spec.rb'
     - 'spec/lib/importer/csv_parser_spec.rb'
     - 'lib/tasks/s3_tasks.rake'
+    - 'spec/forms/hyrax/image_form_spec.rb'
 
 Metrics/ClassLength:
   Exclude:
@@ -92,3 +93,4 @@ RSpec/DescribeClass:
 RSpec/ExampleLength:
   Exclude:
     - 'spec/lib/importer/factory/image_factory_spec.rb'
+    - 'spec/forms/hyrax/image_form_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'pul_uv_rails', github: 'pulibrary/pul_uv_rails', branch: 'master'
 group :test do
   gem 'database_cleaner'
   gem 'factory_bot_rails'
+  gem 'hyrax-spec', '~> 0.2'
   gem 'rspec-activemodel-mocks', '~> 1.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -907,6 +907,8 @@ GEM
       hydra-file_characterization (~> 0.3, >= 0.3.3)
       hydra-pcdm (>= 0.9)
       om (~> 3.1)
+    hyrax-spec (0.2.0)
+      rspec (~> 3.6)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -1206,6 +1208,10 @@ GEM
     rsolr (2.1.0)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
     rspec-activemodel-mocks (1.0.3)
       activemodel (>= 3.0)
       activesupport (>= 3.0)
@@ -1378,6 +1384,7 @@ DEPENDENCIES
   fcrepo_wrapper
   hydra-role-management
   hyrax!
+  hyrax-spec (~> 0.2)
   iiif_manifest
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -55,7 +55,12 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('publisher', :facetable), limit: 5
     config.add_facet_field solr_name('file_format', :facetable), limit: 5
     config.add_facet_field solr_name('technique', :facetable), label: 'Technique', limit: 5
-    config.add_facet_field solr_name('member_of_collections', :symbol), limit: 5, label: 'Collections'
+    config.add_facet_field solr_name('member_of_collections', :symbol), label: 'Collections', limit: 5
+    config.add_facet_field solr_name('proposer', :facetable), label: 'Proposer', limit: 5
+    config.add_facet_field solr_name('project_manager', :facetable), label: 'Project Manager', limit: 5
+    config.add_facet_field solr_name('preservation_level', :facetable), label: 'Preservation Level', limit: 5
+    config.add_facet_field solr_name('project_cycle', :facetable), label: 'Project Cycle', limit: 5
+    config.add_facet_field solr_name('status', :facetable), label: 'Status', limit: 5
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile
@@ -88,6 +93,13 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('identifier', :stored_searchable), helper_method: :index_field_link, field_name: 'identifier'
     config.add_index_field solr_name('embargo_release_date', :stored_sortable, type: :date), label: 'Embargo release date', helper_method: :human_readable_date
     config.add_index_field solr_name('lease_expiration_date', :stored_sortable, type: :date), label: 'Lease expiration date', helper_method: :human_readable_date
+    # rubocop:disable Metrics/LineLength
+    config.add_index_field solr_name('preservation_level', :stored_searchable), label: 'Preservation level', link_to_search: solr_name('preservation_level', :facetable)
+    # rubocop:enable Metrics/LineLength
+    config.add_index_field solr_name('proposer', :stored_searchable), label: 'Proposer', link_to_search: solr_name('proposer', :facetable)
+    config.add_index_field solr_name('project_manager', :stored_searchable), label: 'Project manager', link_to_search: solr_name('project_manager', :facetable)
+    config.add_index_field solr_name('project_cycle', :stored_searchable), label: 'Project cycle', link_to_search: solr_name('project_cycle', :facetable)
+    config.add_index_field solr_name('status', :stored_searchable), label: 'Status', link_to_search: solr_name('status', :facetable)
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -107,6 +119,14 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('resource_type', :stored_searchable), label: 'Resource Type'
     config.add_show_field solr_name('format', :stored_searchable)
     config.add_show_field solr_name('identifier', :stored_searchable)
+    config.add_show_field solr_name('project_name', :stored_searchable)
+    config.add_show_field solr_name('project_description', :stored_searchable)
+    config.add_show_field solr_name('proposer', :stored_searchable)
+    config.add_show_field solr_name('project_manager', :stored_searchable)
+    config.add_show_field solr_name('task_number', :stored_searchable)
+    config.add_show_field solr_name('preservation_level', :stored_searchable)
+    config.add_show_field solr_name('project_cycle', :stored_searchable)
+    config.add_show_field solr_name('status', :stored_searchable)
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -3,11 +3,16 @@
 module Hyrax
   class ImageForm < Hyrax::Forms::WorkForm
     self.model_class = ::Image
-    self.terms += [:alternate_title, :resource_type, :abstract, :accession_number, :call_number, :caption, :catalog_key, :citation, :contributor_role, :creator_role, :genre, :provenance, :physical_description, :related_url_label, :rights_holder, :style_period, :technique] # rubocop:disable Metrics/LineLength
-    self.required_fields = [:title, :date_created, :rights_statement]
+    self.terms += [:alternate_title, :resource_type, :abstract, :accession_number,
+                   :call_number, :caption, :catalog_key, :citation, :contributor_role,
+                   :creator_role, :genre, :provenance, :physical_description, :related_url_label,
+                   :rights_holder, :style_period, :technique, :preservation_level, :status,
+                   :project_name, :project_description, :proposer, :project_manager,
+                   :task_number, :project_cycle]
+    self.required_fields = [:title, :date_created, :rights_statement, :preservation_level, :status]
 
     def primary_terms
-      [:title, :date_created, :accession_number, :creator, :rights_statement, :description]
+      [:title, :date_created, :rights_statement, :preservation_level, :status, :accession_number, :creator, :description]
     end
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,6 +2,7 @@
 #  `rails generate hyrax:work Image`
 class Image < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include ::Schema::Administrative
   include MicroserviceMinter
 
   self.indexer = ImageIndexer

--- a/app/models/schema/administrative.rb
+++ b/app/models/schema/administrative.rb
@@ -48,13 +48,13 @@ module Schema
         index.as :stored_searchable, :facetable
       end
 
-      property :qr_status, predicate: ::Vocab::Donut.qr_status do |index|
+      property :status, predicate: ::Vocab::Donut.status do |index|
         index.as :stored_searchable, :facetable
       end
     end
 
     def mark_reviewed
-      self.qr_status = [REVIEWED_STRING]
+      self.status = [REVIEWED_STRING]
     end
 
     def mark_reviewed!
@@ -63,7 +63,7 @@ module Schema
     end
 
     def reviewed?
-      status.qr_include?(REVIEWED_STRING)
+      status.include?(REVIEWED_STRING)
     end
   end
 end

--- a/app/models/schema/administrative.rb
+++ b/app/models/schema/administrative.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Schema
+  ##
+  # Schema for Donut administrative metadata
+  #
+  # @example applying the administrative schema
+  #
+  #   class WorkType < ActiveFedora::Base
+  #     include ::Hyrax::WorkBehavior
+  #     include ::Schema::Administrative
+  #     include ::Hyrax::BasicMetadata
+  #   end
+  #
+  # @see ActiveFedora::Base
+  # @see Hyrax::WorkBehavior
+  module Administrative
+    extend ActiveSupport::Concern
+
+    REVIEWED_STRING = 'Reviewed'.freeze
+
+    included do
+      property :project_name, predicate: ::Vocab::Donut.project_name do |index|
+        index.as :stored_searchable
+      end
+
+      property :project_description, predicate: ::Vocab::Donut.project_description do |index|
+        index.as :stored_searchable
+      end
+
+      property :proposer, predicate: ::Vocab::Donut.proposer do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      property :project_manager, predicate: ::Vocab::Donut.project_manager do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      property :task_number, predicate: ::Vocab::Donut.task_number do |index|
+        index.as :stored_searchable
+      end
+
+      property :preservation_level, predicate: ::Vocab::Donut.preservation_level do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      property :project_cycle, predicate: ::Vocab::Donut.project_cycle do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      property :qr_status, predicate: ::Vocab::Donut.qr_status do |index|
+        index.as :stored_searchable, :facetable
+      end
+    end
+
+    def mark_reviewed
+      self.qr_status = [REVIEWED_STRING]
+    end
+
+    def mark_reviewed!
+      mark_reviewed
+      save
+    end
+
+    def reviewed?
+      status.qr_include?(REVIEWED_STRING)
+    end
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -74,6 +74,30 @@ class SolrDocument
     fetch(Solrizer.solr_name('physical_description', :stored_searchable), [])
   end
 
+  def preservation_level
+    fetch(Solrizer.solr_name('preservation_level', :stored_searchable), [])
+  end
+
+  def project_cycle
+    fetch(Solrizer.solr_name('project_cycle', :stored_searchable), [])
+  end
+
+  def project_name
+    fetch(Solrizer.solr_name('project_name', :stored_searchable), [])
+  end
+
+  def project_description
+    fetch(Solrizer.solr_name('project_description', :stored_searchable), [])
+  end
+
+  def project_manager
+    fetch(Solrizer.solr_name('project_manager', :stored_searchable), [])
+  end
+
+  def proposer
+    fetch(Solrizer.solr_name('proposer', :stored_searchable), [])
+  end
+
   def provenance
     fetch(Solrizer.solr_name('provenance', :stored_searchable), [])
   end
@@ -86,8 +110,16 @@ class SolrDocument
     fetch(Solrizer.solr_name('rights_holder', :stored_searchable), [])
   end
 
+  def status
+    fetch(Solrizer.solr_name('status', :stored_searchable), [])
+  end
+
   def style_period
     fetch(Solrizer.solr_name('style_period', :stored_searchable), [])
+  end
+
+  def task_number
+    fetch(Solrizer.solr_name('task_number', :stored_searchable), [])
   end
 
   def technique

--- a/app/models/vocab/donut.rb
+++ b/app/models/vocab/donut.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rdf'
+
+module Vocab
+  class Donut < RDF::Vocabulary('http://www.library.northwestern.edu/terms#')
+    term :project_name
+    term :project_description
+    term :proposer
+    term :manager
+    term :task_number
+    term :preservation_level
+    term :cycle
+    term :qr_status
+  end
+end

--- a/app/models/vocab/donut.rb
+++ b/app/models/vocab/donut.rb
@@ -7,10 +7,10 @@ module Vocab
     term :project_name
     term :project_description
     term :proposer
-    term :manager
+    term :project_manager
     term :task_number
     term :preservation_level
-    term :cycle
-    term :qr_status
+    term :project_cycle
+    term :status
   end
 end

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -2,7 +2,15 @@
 #  `rails generate hyrax:work Image`
 module Hyrax
   class ImagePresenter < Hyrax::WorkShowPresenter
-    delegate :abstract, :accession_number, :alternate_title, :ark, :call_number, :caption, :catalog_key, :citation, :contributor_role, :creator_role, :genre, :provenance, :physical_description, :related_url_label, :rights_holder, :style_period, :technique, to: :solr_document # rubocop:disable Metrics/LineLength
+    TERMS = [:abstract, :accession_number, :alternate_title, :ark,
+             :call_number, :caption, :catalog_key, :citation, :contributor_role,
+             :creator_role, :genre, :provenance, :physical_description,
+             :related_url_label, :rights_holder, :style_period, :technique].freeze
+
+    ADMIN_TERMS = [:project_name, :project_description, :proposer, :project_manager,
+                   :task_number, :preservation_level, :project_cycle, :status].freeze
+
+    (TERMS + ADMIN_TERMS).uniq.each { |term| delegate term, to: :solr_document }
 
     Hyrax::MemberPresenterFactory.file_presenter_class = ::FileSetPresenter
 

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -26,3 +26,11 @@
 <%= presenter.attribute_to_html(:source) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:technique) %>
+<%= presenter.attribute_to_html(:preservation_level, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:status, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:project_name) %>
+<%= presenter.attribute_to_html(:project_description) %>
+<%= presenter.attribute_to_html(:proposer, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:project_manager, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:task_number) %>
+<%= presenter.attribute_to_html(:project_cycle, render_as: :faceted) %>

--- a/spec/forms/hyrax/image_form_spec.rb
+++ b/spec/forms/hyrax/image_form_spec.rb
@@ -12,7 +12,30 @@ RSpec.describe Hyrax::ImageForm do
     subject { form.terms }
 
     it 'contains fields that users should are allowed to edit' do
-      is_expected.to include(:resource_type, :abstract, :accession_number, :call_number, :caption, :catalog_key, :citation, :contributor_role, :creator_role, :genre, :provenance, :physical_description, :related_url_label, :rights_holder, :style_period, :technique)
+      is_expected.to include(:resource_type,
+                             :abstract,
+                             :accession_number,
+                             :call_number,
+                             :caption,
+                             :catalog_key,
+                             :citation,
+                             :contributor_role,
+                             :creator_role,
+                             :genre,
+                             :provenance,
+                             :physical_description,
+                             :related_url_label,
+                             :rights_holder,
+                             :style_period,
+                             :technique,
+                             :preservation_level,
+                             :status,
+                             :project_name,
+                             :project_description,
+                             :proposer,
+                             :project_manager,
+                             :task_number,
+                             :project_cycle)
     end
 
     it 'does not contain fields that users should not be allowed to edit' do
@@ -24,7 +47,7 @@ RSpec.describe Hyrax::ImageForm do
     subject { form.required_fields }
 
     it do
-      is_expected.to contain_exactly(:title, :date_created, :rights_statement)
+      is_expected.to contain_exactly(:title, :date_created, :rights_statement, :preservation_level, :status)
     end
   end
 
@@ -32,7 +55,14 @@ RSpec.describe Hyrax::ImageForm do
     subject { form.primary_terms }
 
     it do
-      is_expected.to include(:title, :date_created, :accession_number, :creator, :description)
+      is_expected.to contain_exactly(:title,
+                                     :date_created,
+                                     :accession_number,
+                                     :creator,
+                                     :description,
+                                     :rights_statement,
+                                     :preservation_level,
+                                     :status)
     end
   end
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -35,5 +35,14 @@ RSpec.describe Image do
   it { is_expected.to respond_to(:rights_holder) }
   it { is_expected.to respond_to(:style_period) }
   it { is_expected.to respond_to(:technique) }
+  # Administrative metadata
+  it { is_expected.to respond_to(:project_name) }
+  it { is_expected.to respond_to(:project_description) }
+  it { is_expected.to respond_to(:proposer) }
+  it { is_expected.to respond_to(:project_manager) }
+  it { is_expected.to respond_to(:task_number) }
+  it { is_expected.to respond_to(:preservation_level) }
+  it { is_expected.to respond_to(:project_cycle) }
+  it { is_expected.to respond_to(:status) }
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -32,7 +32,15 @@ RSpec.describe SolrDocument do
       technique_tesim: ['Test title'],
       resource_type_tesim: ['Image'],
       rights_statement_tesim: ['test'],
-      member_of_collection_ids_ssim: ['1']
+      member_of_collection_ids_ssim: ['1'],
+      project_name_tesim: ['Project name'],
+      project_description_tesim: ['Description'],
+      proposer_tesim: ['Proposer'],
+      project_manager_tesim: ['Project manager'],
+      task_number_tesim: ['1'],
+      preservation_level_tesim: ['1'],
+      project_cycle_tesim: ['Project cycle 1'],
+      status_tesim: ['Reviewed']
     }
   end
 

--- a/spec/schema/administrative_spec.rb
+++ b/spec/schema/administrative_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Schema::Administrative do
+  subject(:work) { model_class.new }
+
+  let(:model_class) do
+    Class.new(ActiveFedora::Base) do
+      include ::Schema::Administrative
+
+      def save; end # no-op; stubbed save
+    end
+  end
+
+  it_behaves_like 'a model with admin metadata attributes'
+end

--- a/spec/support/shared_examples/a_model_with_admin_schema.rb
+++ b/spec/support/shared_examples/a_model_with_admin_schema.rb
@@ -1,0 +1,9 @@
+require 'hyrax/spec/matchers'
+
+RSpec.shared_examples 'a model with admin metadata attributes' do
+  it 'has project name' do
+    expect(work)
+      .to have_editable_property(:project_name)
+      .with_predicate(::Vocab::Donut.project_name)
+  end
+end


### PR DESCRIPTION
- Adds `Schema::Administrative` module, which is included in the `Image` model
- Adds `hyrax-spec` gem to Gemfile
- Adds `Vocab::Donut` module for local RDF property definitions
- Adds 'a model with admin schema' shared example
- Updates `Image` form and presenter to include administrative metadata