### PR TITLE
this release has binaries in it

### DIFF
--- a/.ebextensions/01_packages.config
+++ b/.ebextensions/01_packages.config
@@ -11,7 +11,7 @@ commands:
   install_fits:
     command: |
       cd /tmp
-      curl -L -o fits-1.0.5.zip https://github.com/harvard-lts/fits/archive/1.0.5.zip
+      curl -O http://projects.iq.harvard.edu/files/fits/files/fits-1.0.5.zip
       cd /usr/local
       unzip -o /tmp/fits-1.0.5.zip
   install_libreoffice:


### PR DESCRIPTION
So it looks like we have to download the binaries from harvard's hosting, that github repo only contains source code. I ran into this ticket https://github.com/harvard-lts/fits/issues/149 which explains it in more detail

it does look like their hosting is up and running as of today though, i just tested it out and i'm not getting the error anymore