### PR TITLE
ignore the hyrax override file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - 'vendor/**/*'
     - 'db/**/*'
     - 'tmp/**/*'
+    - 'app/actors/hyrax/actors/create_with_remote_files_actor.rb'
   ExtraDetails: true
   TargetRubyVersion: 2.2
 


### PR DESCRIPTION
the `create_with_remote_files_actor` file is taken from hyrax so we could change the settings on one line, but it's causing rubocop to throw up some errors. We should probably just ignore it for now (and until we can figure out a better, long term fix for overriding this file) 

Fixes #102 