### PR TITLE
Add authority select dropdown for subject

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= 
+//=
 //= require turbolinks
 //
 // Required by Blacklight
@@ -20,6 +20,5 @@
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
 //= require blacklight/blacklight
 
-//= require_tree .
+//= require_directory .
 //= require hyrax
-

--- a/app/assets/javascripts/hyrax/authority_select.es6
+++ b/app/assets/javascripts/hyrax/authority_select.es6
@@ -1,0 +1,64 @@
+import Autocomplete from 'hyrax/autocomplete'
+
+/** Class for authority selection on an input field */
+export default class AuthoritySelect {
+    /**
+     * Create an AuthoritySelect
+     * @param {Editor} editor - The parent container
+     * @param {string} selectBox - The selector for the select box
+     * @param {string} inputField - The selector for the input field
+     */
+    constructor(options) {
+    	this.selectBox = options.selectBox
+    	this.inputField = options.inputField
+    	this.selectBoxChange();
+    	this.observeAddedElement();
+    	this.setupAutocomplete();
+    }
+
+    /**
+     * Bind behavior for select box
+     */
+    selectBoxChange() {
+      	var selectBox = this.selectBox;
+      	var inputField = this.inputField;
+        var _this2 = this
+      	$(selectBox).on('change', function(data) {
+      	    var selectBoxValue = $(this).val();
+      	    $(inputField).each(function (data) {
+              $(this).data('autocomplete-url', selectBoxValue);
+      	       _this2.setupAutocomplete()
+            });
+      	});
+    }
+
+    /**
+     * Create an observer to watch for added input elements
+     */
+    observeAddedElement() {
+      	var selectBox = this.selectBox;
+      	var inputField = this.inputField;
+        var _this2 = this
+
+      	var observer = new MutationObserver((mutations) => {
+      	    mutations.forEach((mutation) => {
+      		      $(inputField).each(function (data) {
+                  $(this).data('autocomplete-url', $(selectBox).val())
+      		        _this2.setupAutocomplete();
+                });
+      	    });
+      	});
+
+      	var config = { childList: true };
+      	observer.observe(document.body, config);
+    }
+
+    /**
+     * intialize the Hyrax autocomplete with the fields that you are using
+     */
+    setupAutocomplete() {
+      var inputField = $(this.inputField);
+      var autocomplete = new Autocomplete()
+      autocomplete.setup(inputField, inputField.data('autocomplete'), inputField.data('autocompleteUrl'))
+    }
+}

--- a/app/assets/javascripts/hyrax/editor.es6
+++ b/app/assets/javascripts/hyrax/editor.es6
@@ -1,0 +1,109 @@
+import RelationshipsControl from 'hyrax/relationships/control'
+import SaveWorkControl from 'hyrax/save_work/save_work_control'
+import AdminSetWidget from 'hyrax/editor/admin_set_widget'
+import ControlledVocabulary from 'hyrax/editor/controlled_vocabulary'
+import Autocomplete from 'hyrax/autocomplete'
+import AuthoritySelect from 'hyrax/authority_select'
+
+export default class {
+  /**
+   * initialize the editor behaviors
+   * @param {jQuery} element - The form that has a data-param-key attribute
+   */
+  constructor(element) {
+    this.element = element
+    this.paramKey = element.data('paramKey') // The work type
+    this.adminSetWidget = new AdminSetWidget(element.find('select[id$="_admin_set_id"]'))
+    this.sharingTabElement = $('#tab-share')
+  }
+
+  init() {
+    this.autocomplete()
+    this.controlledVocabularies()
+    this.sharingTab()
+    this.relationshipsControl()
+    this.saveWorkControl()
+    this.saveWorkFixed()
+    this.authoritySelect()
+  }
+
+  // Used when you have a linked data field that can have terms from multiple
+  // authorities.
+  authoritySelect() {
+      $("[data-authority-select]").each(function() {
+          let authoritySelect = $(this).data().authoritySelect
+          let options =  {selectBox: 'select.' + authoritySelect,
+                          inputField: 'input.' + authoritySelect}
+          new AuthoritySelect(options);
+      })
+  }
+
+  // Autocomplete fields for the work edit form (based_near, subject, language, child works)
+  autocomplete() {
+      var autocomplete = new Autocomplete()
+
+      $('[data-autocomplete]').each((function() {
+        var elem = $(this)
+        autocomplete.setup(elem, elem.data('autocomplete'), elem.data('autocompleteUrl'))
+      }))
+
+      $('.multi_value.form-group').manage_fields({
+        add: function(e, element) {
+          var elem = $(element)
+          // Don't mark an added element as readonly even if previous element was
+          // Enable before initializing, as otherwise LinkedData fields remain disabled
+          elem.attr('readonly', false)
+          autocomplete.setup(elem, elem.data('autocomplete'), elem.data('autocompleteUrl'))
+        }
+      })
+  }
+
+  // initialize any controlled vocabulary widgets
+  controlledVocabularies() {
+    this.element.find('.controlled_vocabulary.form-group').each((_idx, controlled_field) =>
+      new ControlledVocabulary(controlled_field, this.paramKey)
+    )
+  }
+
+  // Display the sharing tab if they select an admin set that permits sharing
+  sharingTab() {
+    if(this.adminSetWidget && !this.adminSetWidget.isEmpty()) {
+      this.adminSetWidget.on('change', () => this.sharingTabVisiblity(this.adminSetWidget.isSharing()))
+      this.sharingTabVisiblity(this.adminSetWidget.isSharing())
+    }
+  }
+
+  sharingTabVisiblity(visible) {
+      if (visible)
+         this.sharingTabElement.removeClass('hidden')
+      else
+         this.sharingTabElement.addClass('hidden')
+  }
+
+  relationshipsControl() {
+      let collections = this.element.find('[data-behavior="collection-relationships"]')
+      collections.each((_idx, element) =>
+          new RelationshipsControl(element,
+                                   collections.data('members'),
+                                   collections.data('paramKey'),
+                                   'member_of_collections_attributes',
+                                   'tmpl-collection').init())
+
+      let works = this.element.find('[data-behavior="child-relationships"]')
+      works.each((_idx, element) =>
+          new RelationshipsControl(element,
+                                   works.data('members'),
+                                   works.data('paramKey'),
+                                   'work_members_attributes',
+                                   'tmpl-child-work').init())
+  }
+
+  saveWorkControl() {
+      new SaveWorkControl(this.element.find("#form-progress"), this.adminSetWidget)
+  }
+
+  saveWorkFixed() {
+      // Fixedsticky will polyfill position:sticky
+      this.element.find('#savewidget').fixedsticky()
+  }
+}

--- a/app/services/hyrax/subject_authorities.rb
+++ b/app/services/hyrax/subject_authorities.rb
@@ -1,0 +1,8 @@
+module Hyrax
+  # Provide select options for the subject field
+  class SubjectAuthorities < QaSelectService
+    def initialize
+      super('subjects')
+    end
+  end
+end

--- a/app/views/records/edit_fields/_subject.html.erb
+++ b/app/views/records/edit_fields/_subject.html.erb
@@ -1,0 +1,19 @@
+<% subject_authorities = Hyrax::SubjectAuthorities.new %>
+
+<%=
+  f.input key,
+  as: :multi_value,
+  input_html: {
+    class: 'form-control',
+    data: { 'autocomplete-url' => "/authorities/search/loc/names",
+      'autocomplete' => key }
+  } ,
+  required: f.object.required?(key) %>
+
+  <%= f.input key,
+    input_html: {
+      class: 'form-control image_subject',
+      data: { 'authority-select' => "image_subject" }
+    },
+    collection: subject_authorities.select_active_options,
+    label: t('hyrax.records.edit_fields.subject') %>

--- a/config/authorities/subjects.yml
+++ b/config/authorities/subjects.yml
@@ -1,0 +1,16 @@
+terms:
+    - id: /authorities/search/loc/subjects
+      term: LCSH
+      active: true
+    - id: /authorities/search/assign_fast/all
+      term: FAST
+      active: true
+    - id: /authorities/search/getty/aat
+      term: AAT
+      active: true
+    - id: /authorities/search/getty/ulan
+      term: ULAN
+      active: true
+    - id: /authorities/search/loc/names
+      term: LCNAF
+      active: true

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -194,6 +194,6 @@ end
 
 Date::DATE_FORMATS[:standard] = '%m/%d/%Y'
 
-Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local::TableBasedAuthority')
+# Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -43,6 +43,9 @@ en:
           subject_tesim: Subject
           title_tesim: Title
   hyrax:
+    records:
+      edit_fields:
+        subject: "Select Authority For Subject"
     product_name:           "Hyrax"
     product_twitter_handle: "@HydraSphere"
     institution_name:       "Institution"


### PR DESCRIPTION
- Overrides `app/assets/javascripts/hyrax/authority_select.es6` and `app/assets/javascripts/hyrax/authority_select.es6` from Hyrax to initialize AuthoritySelect fields.
- Adds autocomplete field and associated authority select field for subject.