### PR TITLE
adding contributor multi authority field, but missing viaf

### DIFF
--- a/app/services/hyrax/contributor_authorities.rb
+++ b/app/services/hyrax/contributor_authorities.rb
@@ -1,0 +1,8 @@
+module Hyrax
+  # Provide select options for the subject field
+  class ContributorAuthorities < QaSelectService
+    def initialize
+      super('contributors')
+    end
+  end
+end

--- a/app/views/records/edit_fields/_contributor.html.erb
+++ b/app/views/records/edit_fields/_contributor.html.erb
@@ -1,0 +1,19 @@
+<% contributor_authorities = Hyrax::ContributorAuthorities.new %>
+
+<%=
+  f.input key,
+  as: :multi_value,
+  input_html: {
+    class: 'form-control',
+    data: { 'autocomplete-url' => "/authorities/search/loc/names",
+      'autocomplete' => key }
+  } ,
+  required: f.object.required?(key) %>
+
+  <%= f.input key,
+    input_html: {
+      class: 'form-control image_contributor',
+      data: { 'authority-select' => "image_contributor" }
+    },
+    collection: contributor_authorities.select_active_options,
+    label: t('hyrax.records.edit_fields.contributor') %>

--- a/config/authorities/contributors.yml
+++ b/config/authorities/contributors.yml
@@ -1,0 +1,7 @@
+terms:
+  - id: /authorities/search/getty/ulan
+    term: ULAN
+    active: true
+  - id: /authorities/search/loc/names
+    term: LCNAF
+    active: true

--- a/spec/views/records/edit_fields/_contributor.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_contributor.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'records/edit_fields/_contributor.html.erb', type: :view do
+  let(:image) { Image.new }
+  let(:form) { Hyrax::ImageForm.new(image, nil, controller) }
+  let(:form_template) do
+    %(
+      <%= simple_form_for [main_app, @form] do |f| %>
+        <%= render "records/edit_fields/contributor", f: f, key: 'contributor' %>
+      <% end %>
+    )
+  end
+
+  before do
+    assign(:form, form)
+    render inline: form_template
+  end
+
+  it 'has url for autocomplete service' do
+    expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/loc/names"][data-autocomplete="contributor"]')
+  end
+end


### PR DESCRIPTION
fixes https://github.com/nulib/next-generation-repository/issues/314

It looks like QA doesn't have out of the box support for viaf, but it looks like QA supports various ways of implementing other authorities. I created https://github.com/nulib/next-generation-repository/issues/324 to track adding VIAF 