### PR TITLE
Make preservation level single-valued

### DIFF
--- a/app/models/schema/administrative.rb
+++ b/app/models/schema/administrative.rb
@@ -40,7 +40,7 @@ module Schema
         index.as :stored_searchable
       end
 
-      property :preservation_level, predicate: ::Vocab::Donut.preservation_level do |index|
+      property :preservation_level, predicate: ::Vocab::Donut.preservation_level, multiple: false do |index|
         index.as :stored_searchable, :facetable
       end
 

--- a/app/views/records/edit_fields/_preservation_level.html.erb
+++ b/app/views/records/edit_fields/_preservation_level.html.erb
@@ -1,3 +1,5 @@
-<%= f.input key,
+<%= f.input key, as: :select,
             collection: 1..3,
-            required: f.object.required?(key) %>
+            required: f.object.required?(key),
+            include_blank: true,
+            input_html: { class: 'form-control' } %>


### PR DESCRIPTION
Fixes bug with preservation level not being saved on form submission, because it was sending a single-valued string to a multi-valued property. Changed the property to `multiple: false` to fix the issue.