### PR TITLE
Add bootsnap gem for faster load times

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'hyrax', github: 'samvera/hyrax', branch: 'master'
 gem 'nulib_microservices', github: 'nulib/nulib_microservices'
 
+gem 'bootsnap', require: false
 gem 'config'
 gem 'ezid-client'
 gem 'hydra-role-management'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -689,6 +689,8 @@ GEM
       bootstrap-sass (~> 3.0)
       openseadragon (>= 0.2.0)
       rails
+    bootsnap (1.1.8)
+      msgpack (~> 1.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -1020,6 +1022,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    msgpack (1.2.2)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -1367,6 +1370,7 @@ DEPENDENCIES
   active_elastic_job!
   aws-sdk (~> 3)
   aws-sdk-rails
+  bootsnap
   byebug
   capybara (~> 2.13)
   carrierwave-aws

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup'


### PR DESCRIPTION
Let's make the application boot more quickly! Uses the [bootsnap gem](https://github.com/Shopify/bootsnap) which will be installed by default in Rails 5.2.0. 