### PR TITLE
Use AWS Simple Server Manager Parameter Store...

### DIFF
--- a/.ebextensions/05_mount_efs_volumes.config
+++ b/.ebextensions/05_mount_efs_volumes.config
@@ -8,10 +8,9 @@ files:
     owner: root
     group: root
     content: |
-      #!/bin/bash
-
-      config=$(cat /opt/elasticbeanstalk/deploy/configuration/containerconfiguration | jq -r '.optionsettings | {"aws:elasticbeanstalk:application:environment"}[][]')
-      for var in $config; do eval $var; done
+      jqexpr='[.Parameters[]] | map(((.Name / "/")|last|ascii_upcase) + "=\"" + (.Value) + "\"") | .[]'
+      config=$(aws ssm get-parameters-by-path --path "/${SETTINGS__NAME}/Deploy/" | jq -r $jqexpr)
+      eval $config
 
       # Mount working volume and create working/temp directories
       mkdir -p /var/donut-working

--- a/config/initializers/_aws_config.rb
+++ b/config/initializers/_aws_config.rb
@@ -1,0 +1,31 @@
+if ENV['USE_AWS_SSM']
+  require 'aws-sdk-ssm'
+
+  def add_param_to_hash(hash, param, path)
+    remove_segments = path.split(%r{/}).length
+    placement = param.name.split(%r{/})[remove_segments..-1]
+    placement.reject!(&:empty?)
+    key = placement.pop
+    target = hash
+    placement.each { |segment| target = (target[segment] ||= {}) }
+    target[key] = param.value
+  end
+
+  def aws_param_hash(path: '/')
+    result = {}
+    ssm = Aws::SSM::Client.new
+    next_token = nil
+    loop do
+      response = ssm.get_parameters_by_path(path: path, recursive: true, with_decryption: true, next_token: next_token)
+      response.parameters.each do |param|
+        add_param_to_hash(result, param, path)
+      end
+      next_token = response.next_token
+      break if next_token.nil?
+    end
+    result
+  end
+
+  Settings.add_source!(aws_param_hash(path: "/#{Settings.name}/Settings"))
+  Settings.reload!
+end


### PR DESCRIPTION
... instead of environment variables for deploy-time and runtime configuration

### The Problem

Deploying new code causes Elastic Beanstalk to replace instances and run through health checks and tests.
Changing environment variables does the same.
There's no way to do both at the same time, so any code change that requires an environment update requires two EB deploy cycles.

### The Solution

Use the [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html) for shared configuration settings, and use the EB environment only for things that differ between the webapp and worker environments.

Settings changes will then require a restart or reboot, but not a full redeploy. Code changes and environment changes can happen simultaneously.