### PR TITLE
Set config.iiif_image_server to false

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -111,7 +111,7 @@ Hyrax.config do |config|
   #   * iiif_image_size_default
   #
   # Default is false
-  config.iiif_image_server = true
+  config.iiif_image_server = false
 
   # Returns a URL that resolves to an image provided by a IIIF image server
   config.iiif_image_url_builder = lambda do |file_id, base_url, size|


### PR DESCRIPTION
Temporarily disabled while derivative issue is sorted out via https://github.com/nulib/repodev_planning_and_docs/issues/132 