### PR TITLE
Use controlled vocabulary for language property

### DIFF
--- a/app/assets/javascripts/hyrax/autocomplete.es6
+++ b/app/assets/javascripts/hyrax/autocomplete.es6
@@ -1,6 +1,6 @@
-import Default from './autocomplete/default'
-import Resource from './autocomplete/resource'
-import LinkedData from './autocomplete/linked_data'
+import Default from './autocomplete/default';
+import Resource from './autocomplete/resource';
+import LinkedData from './autocomplete/linked_data';
 
 export default class Autocomplete {
   /**
@@ -9,35 +9,32 @@ export default class Autocomplete {
    * @param {string} fieldName - The name of the field (e.g. 'based_near')
    * @param {string} url - The url for the autocompete search endpoint
    */
-  setup (element, fieldName, url) {
+  setup(element, fieldName, url) {
     switch (fieldName) {
       case 'work':
-        new Resource(
-          element,
-          url,
-          { excluding: element.data('exclude-work') }
-        )
-        break
+        new Resource(element, url, { excluding: element.data('exclude-work') });
+        break;
       case 'collection':
-        new Resource(
-          element,
-          url)
-        break
+        new Resource(element, url);
+        break;
       case 'based_near':
-        new LinkedData(element, url)
-        break
+        new LinkedData(element, url);
+        break;
       case 'genre':
-        new LinkedData(element, url)
-        break
+        new LinkedData(element, url);
+        break;
+      case 'language':
+        new LinkedData(element, url);
+        break;
       case 'style_period':
-        new LinkedData(element, url)
-        break
+        new LinkedData(element, url);
+        break;
       case 'technique':
-        new LinkedData(element, url)
-        break
+        new LinkedData(element, url);
+        break;
       default:
-        new Default(element, url)
-        break
+        new Default(element, url);
+        break;
     }
   }
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -48,7 +48,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('contributor_role', :facetable), label: 'Contributor Role', limit: 5
     config.add_facet_field solr_name('keyword', :facetable), limit: 5
     config.add_facet_field solr_name('subject', :facetable), limit: 5
-    config.add_facet_field solr_name('language', :facetable), limit: 5
+    config.add_facet_field solr_name('language_label', :facetable), label: 'Language', limit: 5
     config.add_facet_field solr_name('based_near_label', :facetable), label: 'Location', limit: 5
     config.add_facet_field solr_name('publisher', :facetable), limit: 5
     config.add_facet_field solr_name('file_format', :facetable), limit: 5
@@ -84,7 +84,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('depositor'), label: 'Owner', helper_method: :link_to_profile
     config.add_index_field solr_name('publisher', :stored_searchable), itemprop: 'publisher', link_to_search: solr_name('publisher', :facetable)
     config.add_index_field solr_name('based_near_label', :stored_searchable), label: 'Location', itemprop: 'contentLocation', link_to_search: solr_name('based_near_label', :facetable)
-    config.add_index_field solr_name('language', :stored_searchable), itemprop: 'inLanguage', link_to_search: solr_name('language', :facetable)
+    config.add_index_field solr_name('language_label', :stored_searchable), label: 'Language', link_to_search: solr_name('language_label', :facetable)
     config.add_index_field solr_name('date_uploaded', :stored_sortable, type: :date), itemprop: 'datePublished', helper_method: :human_readable_date
     config.add_index_field solr_name('date_modified', :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
     config.add_index_field solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
@@ -115,7 +115,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('contributor', :stored_searchable)
     config.add_show_field solr_name('publisher', :stored_searchable)
     config.add_show_field solr_name('based_near_label', :stored_searchable)
-    config.add_show_field solr_name('language', :stored_searchable)
+    config.add_show_field solr_name('language_label', :stored_searchable), label: 'Language'
     config.add_show_field solr_name('date_uploaded', :stored_searchable)
     config.add_show_field solr_name('date_modified', :stored_searchable)
     config.add_show_field solr_name('date_created', :stored_searchable)
@@ -231,7 +231,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('language') do |field|
-      solr_name = solr_name('language', :stored_searchable)
+      solr_name = solr_name('language_label', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -21,6 +21,7 @@ module Hyrax
         {
           style_period_attributes: [:id, :_destroy],
           genre_attributes: [:id, :_destroy],
+          language_attributes: [:id, :destroy],
           technique_attributes: [:id, :_destroy]
         }
       ]

--- a/app/models/controlled_vocabularies/language.rb
+++ b/app/models/controlled_vocabularies/language.rb
@@ -1,0 +1,36 @@
+module ControlledVocabularies
+  class Language < ActiveTriples::Resource
+    def initialize(*args, &block)
+      args[0] = correct_uri_for(args.first) unless args.first.is_a?(Hash)
+      super(*args, &block)
+    end
+
+    # Return a tuple of url & label
+    def solrize
+      return [rdf_subject.to_s] unless label_present
+      [rdf_subject.to_s, { label: "#{preferred_label}$#{rdf_subject}" }]
+    end
+
+    def label_present
+      rdf_label.first.to_s.present? && rdf_label.first.to_s != rdf_subject.to_s
+    end
+
+    def preferred_label
+      english_label = rdf_label.select { |label| label.language == :en }.first.to_s
+      english_label.present? ? english_label : rdf_label.first.to_s
+    end
+
+    private
+
+      def correct_uri_for(id)
+        return if id.nil?
+        return_type = id.class
+        value = case id.to_s
+                when /^info:lc(.+)$/ then "http://id.loc.gov#{Regexp.last_match(1)}"
+                when /^fst(.+)$/ then "http://id.worldcat.org/fast/#{Regexp.last_match(1)}"
+                else id
+                end
+        return_type.new(value)
+      end
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,7 +2,7 @@
 #  `rails generate hyrax:work Image`
 class Image < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
-  include ::Schema::Administrative
+  include ::Schemas::Administrative
   include MicroserviceMinter
 
   self.indexer = ImageIndexer
@@ -88,8 +88,11 @@ class Image < ActiveFedora::Base
 
   id_blank = proc { |attributes| attributes[:id].blank? }
 
-  self.controlled_properties += [:style_period, :genre, :technique]
+  self.controlled_properties += [:language, :style_period, :genre, :technique]
   accepts_nested_attributes_for :style_period, reject_if: id_blank, allow_destroy: true
   accepts_nested_attributes_for :genre, reject_if: id_blank, allow_destroy: true
+  accepts_nested_attributes_for :language, reject_if: id_blank, allow_destroy: true
   accepts_nested_attributes_for :technique, reject_if: id_blank, allow_destroy: true
+
+  apply_schema Schemas::CoreMetadata, Schemas::GeneratedResourceSchemaStrategy.new
 end

--- a/app/models/schemas/administrative.rb
+++ b/app/models/schemas/administrative.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Schema
+module Schemas
   ##
   # Schema for Donut administrative metadata
   #
@@ -8,7 +8,7 @@ module Schema
   #
   #   class WorkType < ActiveFedora::Base
   #     include ::Hyrax::WorkBehavior
-  #     include ::Schema::Administrative
+  #     include ::Schemas::Administrative
   #     include ::Hyrax::BasicMetadata
   #   end
   #

--- a/app/models/schemas/core_metadata.rb
+++ b/app/models/schemas/core_metadata.rb
@@ -1,0 +1,5 @@
+module Schemas
+  class CoreMetadata < ActiveTriples::Schema
+    property :language, predicate: ::RDF::Vocab::DC11.language, class_name: ControlledVocabularies::Language
+  end
+end

--- a/app/models/schemas/generated_resource_schema_strategy.rb
+++ b/app/models/schemas/generated_resource_schema_strategy.rb
@@ -1,0 +1,17 @@
+module Schemas
+  ##
+  # An extension strategy to apply schema changes to the underlying AT model if it
+  # has already been generated.
+  class GeneratedResourceSchemaStrategy < ActiveFedora::SchemaIndexingStrategy
+    ##
+    # @see SchemaIndexingStrategy#apply
+    def apply(object, property)
+      result = super
+
+      klass = object.instance_variable_get(:@generated_resource_class)
+      return result unless klass
+      klass.property property.name, property.to_h
+      result
+    end
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -26,6 +26,7 @@ class SolrDocument
 
   use_extension(Hydra::ContentNegotiation)
 
+  attribute :language_label, Solr::Array, solr_name('language_label')
   attribute :style_period_label, Solr::Array, solr_name('style_period_label')
   attribute :genre_label, Solr::Array, solr_name('genre_label')
   attribute :technique_label, Solr::Array, solr_name('technique_label')

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -4,7 +4,7 @@ module Hyrax
   class ImagePresenter < Hyrax::WorkShowPresenter
     TERMS = [:abstract, :accession_number, :alternate_title, :ark,
              :call_number, :caption, :catalog_key, :citation, :contributor_role,
-             :creator_role, :genre_label, :provenance, :physical_description,
+             :creator_role, :genre_label, :language_label, :provenance, :physical_description,
              :related_url_label, :rights_holder, :style_period_label, :technique_label].freeze
 
     ADMIN_TERMS = [:project_name, :project_description, :proposer, :project_manager,

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -16,7 +16,7 @@
 <%= presenter.attribute_to_html(:genre_label, label: 'Genre') %>
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim') %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:language, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:language_label, render_as: :faceted, label: 'Language') %>
 <%= presenter.attribute_to_html(:physical_description, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted) %>

--- a/app/views/records/edit_fields/_language.html.erb
+++ b/app/views/records/edit_fields/_language.html.erb
@@ -1,8 +1,12 @@
 <%= f.input key,
-            as: :multi_value,
+            as: :controlled_vocabulary,
+            placeholder: 'Search for a language',
             input_html: {
               class: 'form-control',
-              data: { 'autocomplete-url' => "/authorities/search/loc/languages",
+              data: { 'autocomplete-url' => '/authorities/search/loc/languages',
                       'autocomplete' => key }
             },
+            ### Required for the ControlledVocabulary javascript:
+            wrapper_html: { data: { 'autocomplete-url' => '/authorities/search/loc/languages',
+                                    'field-name' => key }},
             required: f.object.required?(key) %>

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -7,5 +7,6 @@ RSpec.describe Image do
 
   it_behaves_like 'a model with admin metadata'
   it_behaves_like 'a model with image metadata'
-  it_behaves_like 'a model with hyrax basic metadata'
+  it_behaves_like 'a model with nul core metadata'
+  it_behaves_like 'a model with hyrax basic metadata', except: :language
 end

--- a/spec/schemas/administrative_spec.rb
+++ b/spec/schemas/administrative_spec.rb
@@ -2,12 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe Schema::Administrative do
+RSpec.describe Schemas::Administrative do
   subject(:work) { model_class.new }
 
   let(:model_class) do
     Class.new(ActiveFedora::Base) do
-      include ::Schema::Administrative
+      include ::Schemas::Administrative
 
       def save; end # no-op; stubbed save
     end

--- a/spec/support/shared_examples/a_model_with_admin_schema.rb
+++ b/spec/support/shared_examples/a_model_with_admin_schema.rb
@@ -1,6 +1,5 @@
-require 'hyrax/spec/matchers'
-
 # rubocop:disable Metrics/BlockLength
+
 RSpec.shared_examples 'a model with admin metadata' do
   it do
     is_expected

--- a/spec/support/shared_examples/a_model_with_nul_core_metadata.rb
+++ b/spec/support/shared_examples/a_model_with_nul_core_metadata.rb
@@ -1,0 +1,3 @@
+RSpec.shared_examples 'a model with nul core metadata' do
+  it { is_expected.to have_editable_property(:language, RDF::Vocab::DC11.language) }
+end


### PR DESCRIPTION
- Overrides Hyrax's basic_metadata language property, in order to add controlled vocabulary functionality
- Renames `app/models/schema` to `app/models/schemas` for consistency
- Adds `a_model_with_nul_core_metadata.rb` shared example