### PR TITLE
Fix RDF::URI deprecations using class method instantiation

### DIFF
--- a/app/models/controlled_vocabularies/contributor_role.rb
+++ b/app/models/controlled_vocabularies/contributor_role.rb
@@ -24,13 +24,12 @@ module ControlledVocabularies
 
       def correct_uri_for(id)
         return if id.nil?
-        return_type = id.class
         value = case id.to_s
                 when /^info:lc(.+)$/ then "http://id.loc.gov#{Regexp.last_match(1)}"
                 when /^fst(.+)$/ then "http://id.worldcat.org/fast/#{Regexp.last_match(1)}"
                 else id
                 end
-        return_type.new(value)
+        ::RDF::URI(value)
       end
   end
 end

--- a/app/models/controlled_vocabularies/language.rb
+++ b/app/models/controlled_vocabularies/language.rb
@@ -24,13 +24,12 @@ module ControlledVocabularies
 
       def correct_uri_for(id)
         return if id.nil?
-        return_type = id.class
         value = case id.to_s
                 when /^info:lc(.+)$/ then "http://id.loc.gov#{Regexp.last_match(1)}"
                 when /^fst(.+)$/ then "http://id.worldcat.org/fast/#{Regexp.last_match(1)}"
                 else id
                 end
-        return_type.new(value)
+        ::RDF::URI(value)
       end
   end
 end


### PR DESCRIPTION
Fixes deprecation warning `[DEPRECATION] URI#to_hash is deprecated, use URI#to_h instead.` with solution described in https://github.com/ruby-rdf/rdf/issues/341