### PR TITLE
Override keyword predicate

### DIFF
--- a/app/models/schemas/core_metadata.rb
+++ b/app/models/schemas/core_metadata.rb
@@ -1,5 +1,6 @@
 module Schemas
   class CoreMetadata < ActiveTriples::Schema
+    property :keyword,  predicate: ::RDF::Vocab::SCHEMA.keywords
     property :language, predicate: ::RDF::Vocab::DC11.language, class_name: ControlledVocabularies::Language
   end
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -8,5 +8,5 @@ RSpec.describe Image do
   it_behaves_like 'a model with admin metadata'
   it_behaves_like 'a model with image metadata'
   it_behaves_like 'a model with nul core metadata'
-  it_behaves_like 'a model with hyrax basic metadata', except: :language
+  it_behaves_like 'a model with hyrax basic metadata', except: [:keyword, :language]
 end

--- a/spec/support/shared_examples/a_model_with_nul_core_metadata.rb
+++ b/spec/support/shared_examples/a_model_with_nul_core_metadata.rb
@@ -1,3 +1,4 @@
 RSpec.shared_examples 'a model with nul core metadata' do
+  it { is_expected.to have_editable_property(:keyword, RDF::Vocab::SCHEMA.keywords) }
   it { is_expected.to have_editable_property(:language, RDF::Vocab::DC11.language) }
 end


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/298

- Overrides keyword predicate in `Schemas::CoreMetadata`
- Updates `a_model_with_nul_core_metadata.rb` shared example
- Excludes `:keyword` from 'a model with hyrax basic metadata' in `image_spec`

![keywords](https://user-images.githubusercontent.com/1395707/36740982-97b60da0-1ba9-11e8-98e3-4c533bed17ce.png)