### PR TITLE
Remove related_url_label property from the Image model, forms, specs

### DIFF
--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -5,7 +5,7 @@ module Hyrax
     self.model_class = ::Image
     self.terms += [:alternate_title, :resource_type, :abstract, :accession_number,
                    :call_number, :caption, :catalog_key, :citation, :contributor_role,
-                   :creator_role, :genre, :provenance, :physical_description, :related_url_label,
+                   :creator_role, :genre, :provenance, :physical_description,
                    :rights_holder, :style_period, :technique, :preservation_level, :status,
                    :project_name, :project_description, :proposer, :project_manager,
                    :task_number, :project_cycle, :nul_creator, :nul_subject, :nul_contributor]

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -68,10 +68,6 @@ class Image < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :related_url_label, predicate: ::RDF::RDFS.label, multiple: true do |index|
-    index.as :stored_searchable
-  end
-
   property :rights_holder, predicate: ::RDF::Vocab::DC.rightsHolder, multiple: true do |index|
     index.as :stored_searchable
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -120,10 +120,6 @@ class SolrDocument
     fetch(Solrizer.solr_name('provenance', :stored_searchable), [])
   end
 
-  def related_url_label
-    fetch(Solrizer.solr_name('related_url_label', :stored_searchable), [])
-  end
-
   def rights_holder
     fetch(Solrizer.solr_name('rights_holder', :stored_searchable), [])
   end

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -5,7 +5,7 @@ module Hyrax
     TERMS = [:abstract, :accession_number, :alternate_title, :ark,
              :call_number, :caption, :catalog_key, :citation, :contributor_role_label,
              :creator_role, :genre_label, :language_label, :provenance, :physical_description,
-             :related_url_label, :rights_holder, :style_period_label, :technique_label,
+             :rights_holder, :style_period_label, :technique_label,
              :nul_creator, :nul_subject, :nul_contributor].freeze
 
     ADMIN_TERMS = [:project_name, :project_description, :proposer, :project_manager,

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -17,7 +17,6 @@ FactoryBot.define do
     genre ['Postmodern']
     provenance ['The example provenance']
     physical_description ['Wood 6cm x 7cm']
-    related_url_label ['Related Website']
     rights_holder ['Northwestern University Libraries']
     style_period ['Renaissance']
     technique ['Gauche']

--- a/spec/forms/hyrax/image_form_spec.rb
+++ b/spec/forms/hyrax/image_form_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Hyrax::ImageForm do
                              :genre,
                              :provenance,
                              :physical_description,
-                             :related_url_label,
                              :rights_holder,
                              :style_period,
                              :technique,

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe SolrDocument do
       genre_tesim: ['Postmodern'],
       provenance: ['The example provenance'],
       physical_description_tesim: ['Wood 6cm x 7cm'],
-      related_url_label_tesim: ['Related Website'],
       rights_holder_tesim: ['Northwestern University Libraries'],
       style_period_tesim: ['Renaissance'],
       technique_tesim: ['Test title'],

--- a/spec/support/shared_examples/a_model_with_image_metadata.rb
+++ b/spec/support/shared_examples/a_model_with_image_metadata.rb
@@ -12,7 +12,6 @@ RSpec.shared_examples 'a model with image metadata' do
   it { is_expected.to have_editable_property(:genre, 'http://www.europeana.eu/schemas/edm/hasType') }
   it { is_expected.to have_editable_property(:physical_description, RDF::Vocab::Bibframe.extent) }
   it { is_expected.to have_editable_property(:provenance, RDF::Vocab::DC.provenance) }
-  it { is_expected.to have_editable_property(:related_url_label, RDF::RDFS.label) }
   it { is_expected.to have_editable_property(:rights_holder, RDF::Vocab::DC.rightsHolder) }
   it { is_expected.to have_editable_property(:style_period, 'http://purl.org/vra/StylePeriod') }
   it { is_expected.to have_editable_property(:technique, 'http://purl.org/vra/Technique') }


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/393

- Removes `related_url_label` property from the Image model and references to the property in the solr_document model, presenter, forms and specs.