### PR TITLE
Update ffi to latest, fixing bundle install error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -831,7 +831,7 @@ GEM
       faraday
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
-    ffi (1.9.21)
+    ffi (1.9.23)
     flipflop (2.3.1)
       activesupport (>= 4.0)
     flot-rails (0.0.7)


### PR DESCRIPTION
Fixes the error described in this issue: https://github.com/ffi/ffi/issues/608