### PR TITLE
Handle single valued properties

### DIFF
--- a/lib/importer/csv_parser.rb
+++ b/lib/importer/csv_parser.rb
@@ -80,7 +80,7 @@ module Importer
       def extract_field(header, val, processed)
         return unless val
         case header
-        when 'type', 'id'
+        when 'type', 'id', 'accession_number', 'ark', 'call_number', 'preservation_level'
           # type and id are singular
           processed[header.to_sym] = val
         when /^(created|issued|date_copyrighted|date_valid)_(.*)$/


### PR DESCRIPTION
Currently, trying to run batch with a value for any of our single valued fields (accession_number, call_number, etc) causes the entire batch to fail and enter a retry loop

```
E, [2018-02-27T17:02:58.642000 #24565] ERROR -- : [f10a5ccd-bb26-47a3-9a63-fc319334f575] [ActiveJob] [S3ImportJob] [65858cc0-bcfb-4514-93ed-6accbc3b90f4] Error performing S3ImportJob (Job ID: 65858cc0-bcfb-4514-93ed-6accbc3b90f4) from BetterActiveElasticJob(batch_ingest) in 19367.06ms: ArgumentError (You attempted to set the property `accession_number' of  to an enumerable value. However, this property is declared as singular.):
```