### PR TITLE
Dockerize test environment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Metrics/BlockLength:
     - 'spec/lib/importer/csv_parser_spec.rb'
     - 'lib/tasks/s3_tasks.rake'
     - 'spec/forms/hyrax/image_form_spec.rb'
+    - 'lib/tasks/donut.rake'
 
 Metrics/ClassLength:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,15 @@ sudo: false
 cache: bundler
 
 services:
-  - redis
   - docker
 
 before_install:
-  - 'docker pull minio/minio'
-  - 'docker run -d -p 127.0.0.1:9000:9000 -e "MINIO_ACCESS_KEY=minio-dev-key" -e "MINIO_SECRET_KEY=minio-dev-secret" minio/minio server /data'
   - 'gem update --system'
   - 'gem update bundler'
 
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-    - AWS_ACCESS_KEY_ID=minio-dev-key
-    - AWS_SECRET_ACCESS_KEY=minio-dev-secret
-    - AWS_DEFAULT_REGION=us-east-1
   matrix:
     - TEST_SUITE=rspec
     - TEST_SUITE=rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,9 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 group :development, :test do
+  gem 'docker-compose'
+  gem 'fcrepo_wrapper'
+  gem 'rspec-rails'
   gem 'solr_wrapper', '>= 0.3'
 end
 
@@ -83,10 +86,6 @@ gem 'devise'
 gem 'devise-guests', '~> 0.6'
 gem 'jquery-rails'
 gem 'rsolr', '>= 1.0'
-group :development, :test do
-  gem 'fcrepo_wrapper'
-  gem 'rspec-rails'
-end
 
 group :aws, :test do
   gem 'active_elastic_job', github: 'nulib/active-elastic-job', branch: 'latest-aws-sdk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -681,6 +681,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
+    backticks (1.0.2)
     bcp47 (0.3.3)
       i18n
     bcrypt (3.1.11)
@@ -774,6 +775,8 @@ GEM
     devise-guests (0.6.0)
       devise
     diff-lcs (1.3)
+    docker-compose (1.1.8)
+      backticks (~> 1.0)
     dropbox_api (0.1.10)
       faraday (~> 0.9, ~> 0.8)
       oauth2 (~> 1.1)
@@ -1382,6 +1385,7 @@ DEPENDENCIES
   database_cleaner
   devise
   devise-guests (~> 0.6)
+  docker-compose
   ezid-client
   factory_bot_rails
   fcrepo_wrapper

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Donut is a Hydra head based on [Hyrax](http://github.com/projecthydra-labs/hyrax
 * Install dependencies: `bundle install`
 * Setup the database: `rake db:migrate`
 * Generate roles: `rake generate_roles`
-* Run `docker-compose up` in a separate tab to start solr, fedora, cantaloupe, and minio.
+* Run `rake donut:server:dev` in a separate tab to start solr, fedora, cantaloupe, and minio.
 * Create the default admin set: `rake hyrax:default_admin_set:create`
 * Load the workflows in `config/workflows`: `rake hyrax:workflow:load`
 
@@ -33,12 +33,6 @@ Donut is a Hydra head based on [Hyrax](http://github.com/projecthydra-labs/hyrax
 Run `bundle exec rake s3:setup`, which creates a new bucket and populates it with our fixtures. If you already have the bucket, then run `bundle exec rake s3:populate_batch_bucket` to upload the fixture data to the bucket.
 
 ## Running the Tests
-
-Start minio on its own in a separate tab:
-
-```sh
-$ docker-compose up minio
-```
 
 Run the test suite:
 
@@ -56,7 +50,7 @@ $ rake donut:ci:rspec
 You may also want to run the Fedora and Solr servers in one window with:
 
 ```sh
-$ rake hydra:test_server
+$ rake donut:server:test
 ```
 
 And run the test suite in another window:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,8 +1,8 @@
 aws:
   endpoint: http://127.0.0.1:9000
   region: us-east-1
-  aws_access_key_id: minio-dev-key
-  aws_secret_key_id: minio-dev-secret
+  aws_access_key_id: minio-test-key
+  aws_secret_key_id: minio-test-secret
   buckets:
     batch:   test-batch
     uploads: test-uploads

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,43 @@
+version: '2'
+
+volumes:
+  fedora-test:
+  solr-test:
+  minio-test:
+
+services:
+  fedora:
+    image: nulib/fcrepo4
+    volumes:
+      - fedora-test:/data
+    ports:
+      - "8986:8080"
+  solr:
+    image: solr:7.2-alpine
+    ports:
+      - "8985:8983"
+    volumes:
+      - solr-test:/opt/solr/server/solr/mycores
+      - ./solr:/solr_config
+    entrypoint:
+      - docker-entrypoint.sh
+      - solr-precreate
+      - hydra-test
+      - /solr_config/config
+  minio:
+    image: minio/minio
+    ports:
+      - "9000:9000"
+    volumes:
+      - minio-test:/data
+    environment:
+      MINIO_ACCESS_KEY: minio-test-key
+      MINIO_SECRET_KEY: minio-test-secret
+    command:
+      - minio
+      - server
+      - /data
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
- Uses docker containers instead of `solr_wrapper` and `fcrepo_wrapper`
- Adds rake tasks for starting/stopping/cleaning dev and test server stacks
- Updates README to reflect those changes