### PR TITLE
Add docker health checks and saner waits

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 group :development, :test do
+  gem 'docker-api'
   gem 'docker-compose'
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -775,6 +775,9 @@ GEM
     devise-guests (0.6.0)
       devise
     diff-lcs (1.3)
+    docker-api (1.34.0)
+      excon (>= 0.47.0)
+      multi_json
     docker-compose (1.1.8)
       backticks (~> 1.0)
     dropbox_api (0.1.10)
@@ -820,6 +823,7 @@ GEM
     erubi (1.7.0)
     ethon (0.11.0)
       ffi (>= 1.3.0)
+    excon (0.60.0)
     execjs (2.7.0)
     ezid-client (1.7.1)
       hashie (~> 3.4, >= 3.4.3)
@@ -1385,6 +1389,7 @@ DEPENDENCIES
   database_cleaner
   devise
   devise-guests (~> 0.6)
+  docker-api
   docker-compose
   ezid-client
   factory_bot_rails

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 volumes:
   fedora-test:
@@ -12,6 +12,11 @@ services:
       - fedora-test:/data
     ports:
       - "8986:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/rest/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
   solr:
     image: solr:7.2-alpine
     ports:
@@ -24,6 +29,11 @@ services:
       - solr-precreate
       - hydra-test
       - /solr_config/config
+    healthcheck:
+      test: ["CMD", "wget", "-O", "/dev/null", "http://localhost:8983/solr/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
   minio:
     image: minio/minio
     ports:
@@ -41,3 +51,8 @@ services:
     image: redis:alpine
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 volumes:
   fedora:
@@ -12,6 +12,11 @@ services:
       - fedora:/data
     ports:
       - "8984:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/rest/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
   solr:
     image: solr:7.2-alpine
     ports:
@@ -24,12 +29,22 @@ services:
       - solr-precreate
       - hydra-development
       - /solr_config/config
+    healthcheck:
+      test: ["CMD", "wget", "-O", "/dev/null", "http://localhost:8983/solr/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
   cantaloupe:
     image: nulib/cantaloupe
     ports:
       - "8182:8182"
     volumes:
       - ./tmp/derivatives:/var/lib/cantaloupe/images
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8182/iiif/2/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
   minio:
     image: minio/minio
     ports:
@@ -47,3 +62,8 @@ services:
     image: redis:alpine
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/lib/docker_controller.rb
+++ b/lib/docker_controller.rb
@@ -1,0 +1,63 @@
+class DockerController
+  attr_reader :dc, :cleanup
+
+  def initialize(config: 'docker-compose.yml', cleanup: false)
+    @dc = Docker::Compose::Session.new(dir: Rails.root, file: config)
+    @cleanup = cleanup
+  end
+
+  def status
+    containers = dc.ps.map(&:id)
+    statuses = containers.map do |container|
+      begin
+        status = Docker::Container.get(container).info['State']['Health']['Status']
+        [container, status]
+      rescue
+        [container, 'unknown']
+      end
+    end
+    Hash[statuses]
+  end
+
+  def wait_for_services
+    Timeout.timeout(120) do
+      $stderr.print 'Waiting up to two minutes for services to become healthy.'
+      loop do
+        break if status.all? { |_k, v| v == 'healthy' }
+        $stderr.print '.'
+        sleep 2
+      end
+      $stderr.puts
+    end
+    true
+  rescue Timeout::Error
+    raise 'Timed out waiting for services to become healthy'
+  end
+
+  def run
+    dc.up(detached: block_given?)
+    return true unless block_given?
+
+    begin
+      wait_for_services
+      yield
+    ensure
+      down
+    end
+  end
+
+  def start(&block)
+    old_trap = Signal.trap('INT') do
+      down
+      raise SystemExit
+    end
+    run(&block)
+  ensure
+    Signal.trap('INT', old_trap)
+  end
+  alias with_containers start
+
+  def down
+    dc.run!('down', v: cleanup)
+  end
+end


### PR DESCRIPTION
Instead of waiting 20 seconds for services to come up, add actual health checks to the `docker-compose` files and use them to determine if/when the services are ready. Also do a better job of trapping `SIGINT` and making sure services come down on exit.