### PR TITLE
More dev perks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ end
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.1'
-# Use sqlite3 as the database for Active Record
+# Install both postgres & sqlite3 adapters
+gem 'pg'
 gem 'sqlite3'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
@@ -99,8 +100,4 @@ group :aws do
   gem 'cloudfront-signer'
   gem 'redis-rails'
   gem 'zk'
-end
-
-group :postgres, optional: true do
-  gem 'pg'
 end

--- a/bin/rake
+++ b/bin/rake
@@ -1,9 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,20 +5,25 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  adapter: postgresql
+  host: localhost
+  encoding: unicode
+  pool: 5
+  username: donut
+  password: d0nut
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  port: 5433
+  database: donut_dev
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  port: 5434
+  database: donut_test
 
 production:
   <<: *default

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,9 +1,9 @@
 development:
   host: localhost
-  port: 6379
+  port: 6380
 test:
   host: localhost
-  port: 6380
+  port: 6381
 production:
   host: <%= ENV['REDIS_HOST'] || 'localhost' %>
   port: <%= ENV['REDIS_PORT'] || 6379 %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,5 +1,5 @@
 aws:
-  endpoint: http://127.0.0.1:9000
+  endpoint: http://127.0.0.1:9001
   region: us-east-1
   aws_access_key_id: minio-dev-key
   aws_secret_key_id: minio-dev-secret
@@ -7,4 +7,4 @@ aws:
     uploads: dev-uploads
     batch: dev-batch
 iiif:
-  endpoint: http://localhost:8182/iiif/2/
+  endpoint: http://localhost:8183/iiif/2/

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,5 +1,5 @@
 aws:
-  endpoint: http://127.0.0.1:9010
+  endpoint: http://127.0.0.1:9002
   region: us-east-1
   aws_access_key_id: minio-test-key
   aws_secret_key_id: minio-test-secret

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,10 @@
 
 ActiveRecord::Schema.define(version: 20180302203158) do
 
-  create_table "bookmarks", force: :cascade do |t|
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "bookmarks", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -24,7 +27,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "checksum_audit_logs", force: :cascade do |t|
+  create_table "checksum_audit_logs", id: :serial, force: :cascade do |t|
     t.string "file_set_id"
     t.string "file_id"
     t.string "checked_uri"
@@ -50,7 +53,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
   end
 
   create_table "collection_type_participants", force: :cascade do |t|
-    t.integer "hyrax_collection_type_id"
+    t.bigint "hyrax_collection_type_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -59,7 +62,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["hyrax_collection_type_id"], name: "hyrax_collection_type_id"
   end
 
-  create_table "content_blocks", force: :cascade do |t|
+  create_table "content_blocks", id: :serial, force: :cascade do |t|
     t.string "name"
     t.text "value"
     t.datetime "created_at", null: false
@@ -67,7 +70,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.string "external_key"
   end
 
-  create_table "curation_concerns_operations", force: :cascade do |t|
+  create_table "curation_concerns_operations", id: :serial, force: :cascade do |t|
     t.string "status"
     t.string "operation_type"
     t.string "job_class"
@@ -88,7 +91,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
   end
 
-  create_table "featured_works", force: :cascade do |t|
+  create_table "featured_works", id: :serial, force: :cascade do |t|
     t.integer "order", default: 5
     t.string "work_id"
     t.datetime "created_at", null: false
@@ -97,7 +100,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["work_id"], name: "index_featured_works_on_work_id"
   end
 
-  create_table "file_download_stats", force: :cascade do |t|
+  create_table "file_download_stats", id: :serial, force: :cascade do |t|
     t.datetime "date"
     t.integer "downloads"
     t.string "file_id"
@@ -108,7 +111,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["user_id"], name: "index_file_download_stats_on_user_id"
   end
 
-  create_table "file_view_stats", force: :cascade do |t|
+  create_table "file_view_stats", id: :serial, force: :cascade do |t|
     t.datetime "date"
     t.integer "views"
     t.string "file_id"
@@ -134,14 +137,14 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["machine_id"], name: "index_hyrax_collection_types_on_machine_id", unique: true
   end
 
-  create_table "hyrax_features", force: :cascade do |t|
+  create_table "hyrax_features", id: :serial, force: :cascade do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "job_io_wrappers", force: :cascade do |t|
+  create_table "job_io_wrappers", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "uploaded_file_id"
     t.string "file_set_id"
@@ -155,7 +158,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["user_id"], name: "index_job_io_wrappers_on_user_id"
   end
 
-  create_table "mailboxer_conversation_opt_outs", force: :cascade do |t|
+  create_table "mailboxer_conversation_opt_outs", id: :serial, force: :cascade do |t|
     t.string "unsubscriber_type"
     t.integer "unsubscriber_id"
     t.integer "conversation_id"
@@ -163,13 +166,13 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
   end
 
-  create_table "mailboxer_conversations", force: :cascade do |t|
+  create_table "mailboxer_conversations", id: :serial, force: :cascade do |t|
     t.string "subject", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "mailboxer_notifications", force: :cascade do |t|
+  create_table "mailboxer_notifications", id: :serial, force: :cascade do |t|
     t.string "type"
     t.text "body"
     t.string "subject", default: ""
@@ -192,7 +195,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["type"], name: "index_mailboxer_notifications_on_type"
   end
 
-  create_table "mailboxer_receipts", force: :cascade do |t|
+  create_table "mailboxer_receipts", id: :serial, force: :cascade do |t|
     t.string "receiver_type"
     t.integer "receiver_id"
     t.integer "notification_id", null: false
@@ -209,18 +212,18 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end
 
-  create_table "minter_states", force: :cascade do |t|
+  create_table "minter_states", id: :serial, force: :cascade do |t|
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
     t.text "counters"
-    t.integer "seq", limit: 8, default: 0
+    t.bigint "seq", default: 0
     t.binary "rand"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["namespace"], name: "index_minter_states_on_namespace", unique: true
   end
 
-  create_table "permission_template_accesses", force: :cascade do |t|
+  create_table "permission_template_accesses", id: :serial, force: :cascade do |t|
     t.integer "permission_template_id"
     t.string "agent_type"
     t.string "agent_id"
@@ -230,7 +233,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["permission_template_id", "agent_id", "agent_type", "access"], name: "uk_permission_template_accesses", unique: true
   end
 
-  create_table "permission_templates", force: :cascade do |t|
+  create_table "permission_templates", id: :serial, force: :cascade do |t|
     t.string "source_id"
     t.string "visibility"
     t.datetime "created_at"
@@ -240,7 +243,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["source_id"], name: "index_permission_templates_on_source_id", unique: true
   end
 
-  create_table "proxy_deposit_requests", force: :cascade do |t|
+  create_table "proxy_deposit_requests", id: :serial, force: :cascade do |t|
     t.string "work_id", null: false
     t.integer "sending_user_id", null: false
     t.integer "receiving_user_id", null: false
@@ -254,7 +257,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["sending_user_id"], name: "index_proxy_deposit_requests_on_sending_user_id"
   end
 
-  create_table "proxy_deposit_rights", force: :cascade do |t|
+  create_table "proxy_deposit_rights", id: :serial, force: :cascade do |t|
     t.integer "grantor_id"
     t.integer "grantee_id"
     t.datetime "created_at", null: false
@@ -271,7 +274,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
   end
 
   create_table "qa_local_authority_entries", force: :cascade do |t|
-    t.integer "local_authority_id"
+    t.bigint "local_authority_id"
     t.string "label"
     t.string "uri"
     t.datetime "created_at", null: false
@@ -285,15 +288,15 @@ ActiveRecord::Schema.define(version: 20180302203158) do
   end
 
   create_table "roles_users", id: false, force: :cascade do |t|
-    t.integer "role_id"
-    t.integer "user_id"
+    t.bigint "role_id"
+    t.bigint "user_id"
     t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
     t.index ["role_id"], name: "index_roles_users_on_role_id"
     t.index ["user_id", "role_id"], name: "index_roles_users_on_user_id_and_role_id"
     t.index ["user_id"], name: "index_roles_users_on_user_id"
   end
 
-  create_table "searches", force: :cascade do |t|
+  create_table "searches", id: :serial, force: :cascade do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -302,7 +305,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "single_use_links", force: :cascade do |t|
+  create_table "single_use_links", id: :serial, force: :cascade do |t|
     t.string "downloadKey"
     t.string "path"
     t.string "itemId"
@@ -311,7 +314,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "sipity_agents", force: :cascade do |t|
+  create_table "sipity_agents", id: :serial, force: :cascade do |t|
     t.string "proxy_for_id", null: false
     t.string "proxy_for_type", null: false
     t.datetime "created_at", null: false
@@ -319,7 +322,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["proxy_for_id", "proxy_for_type"], name: "sipity_agents_proxy_for", unique: true
   end
 
-  create_table "sipity_comments", force: :cascade do |t|
+  create_table "sipity_comments", id: :serial, force: :cascade do |t|
     t.integer "entity_id", null: false
     t.integer "agent_id", null: false
     t.text "comment"
@@ -330,7 +333,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["entity_id"], name: "index_sipity_comments_on_entity_id"
   end
 
-  create_table "sipity_entities", force: :cascade do |t|
+  create_table "sipity_entities", id: :serial, force: :cascade do |t|
     t.string "proxy_for_global_id", null: false
     t.integer "workflow_id", null: false
     t.integer "workflow_state_id"
@@ -341,7 +344,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["workflow_state_id"], name: "index_sipity_entities_on_workflow_state_id"
   end
 
-  create_table "sipity_entity_specific_responsibilities", force: :cascade do |t|
+  create_table "sipity_entity_specific_responsibilities", id: :serial, force: :cascade do |t|
     t.integer "workflow_role_id", null: false
     t.string "entity_id", null: false
     t.integer "agent_id", null: false
@@ -353,7 +356,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["workflow_role_id"], name: "sipity_entity_specific_responsibilities_role"
   end
 
-  create_table "sipity_notifiable_contexts", force: :cascade do |t|
+  create_table "sipity_notifiable_contexts", id: :serial, force: :cascade do |t|
     t.integer "scope_for_notification_id", null: false
     t.string "scope_for_notification_type", null: false
     t.string "reason_for_notification", null: false
@@ -366,7 +369,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["scope_for_notification_id", "scope_for_notification_type"], name: "sipity_notifiable_contexts_concern"
   end
 
-  create_table "sipity_notification_recipients", force: :cascade do |t|
+  create_table "sipity_notification_recipients", id: :serial, force: :cascade do |t|
     t.integer "notification_id", null: false
     t.integer "role_id", null: false
     t.string "recipient_strategy", null: false
@@ -378,7 +381,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["role_id"], name: "sipity_notification_recipients_role"
   end
 
-  create_table "sipity_notifications", force: :cascade do |t|
+  create_table "sipity_notifications", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "notification_type", null: false
     t.datetime "created_at", null: false
@@ -387,7 +390,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["notification_type"], name: "index_sipity_notifications_on_notification_type"
   end
 
-  create_table "sipity_roles", force: :cascade do |t|
+  create_table "sipity_roles", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -395,7 +398,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["name"], name: "index_sipity_roles_on_name", unique: true
   end
 
-  create_table "sipity_workflow_actions", force: :cascade do |t|
+  create_table "sipity_workflow_actions", id: :serial, force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.integer "resulting_workflow_state_id"
     t.string "name", null: false
@@ -406,7 +409,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["workflow_id"], name: "sipity_workflow_actions_workflow"
   end
 
-  create_table "sipity_workflow_methods", force: :cascade do |t|
+  create_table "sipity_workflow_methods", id: :serial, force: :cascade do |t|
     t.string "service_name", null: false
     t.integer "weight", null: false
     t.integer "workflow_action_id", null: false
@@ -415,7 +418,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["workflow_action_id"], name: "index_sipity_workflow_methods_on_workflow_action_id"
   end
 
-  create_table "sipity_workflow_responsibilities", force: :cascade do |t|
+  create_table "sipity_workflow_responsibilities", id: :serial, force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "workflow_role_id", null: false
     t.datetime "created_at", null: false
@@ -423,7 +426,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["agent_id", "workflow_role_id"], name: "sipity_workflow_responsibilities_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_roles", force: :cascade do |t|
+  create_table "sipity_workflow_roles", id: :serial, force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.integer "role_id", null: false
     t.datetime "created_at", null: false
@@ -431,7 +434,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["workflow_id", "role_id"], name: "sipity_workflow_roles_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_action_permissions", force: :cascade do |t|
+  create_table "sipity_workflow_state_action_permissions", id: :serial, force: :cascade do |t|
     t.integer "workflow_role_id", null: false
     t.integer "workflow_state_action_id", null: false
     t.datetime "created_at", null: false
@@ -439,7 +442,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["workflow_role_id", "workflow_state_action_id"], name: "sipity_workflow_state_action_permissions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_actions", force: :cascade do |t|
+  create_table "sipity_workflow_state_actions", id: :serial, force: :cascade do |t|
     t.integer "originating_workflow_state_id", null: false
     t.integer "workflow_action_id", null: false
     t.datetime "created_at", null: false
@@ -447,7 +450,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["originating_workflow_state_id", "workflow_action_id"], name: "sipity_workflow_state_actions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_states", force: :cascade do |t|
+  create_table "sipity_workflow_states", id: :serial, force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -456,7 +459,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["workflow_id", "name"], name: "sipity_type_state_aggregate", unique: true
   end
 
-  create_table "sipity_workflows", force: :cascade do |t|
+  create_table "sipity_workflows", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "label"
     t.text "description"
@@ -468,20 +471,20 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
   end
 
-  create_table "tinymce_assets", force: :cascade do |t|
+  create_table "tinymce_assets", id: :serial, force: :cascade do |t|
     t.string "file"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "trophies", force: :cascade do |t|
+  create_table "trophies", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.string "work_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "uploaded_files", force: :cascade do |t|
+  create_table "uploaded_files", id: :serial, force: :cascade do |t|
     t.string "file"
     t.integer "user_id"
     t.string "file_set_uri"
@@ -491,7 +494,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end
 
-  create_table "user_stats", force: :cascade do |t|
+  create_table "user_stats", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.datetime "date"
     t.integer "file_views"
@@ -543,7 +546,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["username"], name: "index_users_on_username"
   end
 
-  create_table "version_committers", force: :cascade do |t|
+  create_table "version_committers", id: :serial, force: :cascade do |t|
     t.string "obj_id"
     t.string "datastream_id"
     t.string "version_id"
@@ -552,7 +555,7 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "work_view_stats", force: :cascade do |t|
+  create_table "work_view_stats", id: :serial, force: :cascade do |t|
     t.datetime "date"
     t.integer "work_views"
     t.string "work_id"
@@ -563,4 +566,12 @@ ActiveRecord::Schema.define(version: 20180302203158) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "collection_type_participants", "hyrax_collection_types"
+  add_foreign_key "curation_concerns_operations", "users"
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
+  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
+  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
+  add_foreign_key "permission_template_accesses", "permission_templates"
+  add_foreign_key "qa_local_authority_entries", "qa_local_authorities", column: "local_authority_id"
+  add_foreign_key "uploaded_files", "users"
 end

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,15 +1,28 @@
-version: '3'
+version: '3.4'
 
 volumes:
-  fedora-test:
-  solr-test:
-  minio-test:
+  db:
+  fedora:
+  solr:
+  minio:
+
+x-container-prefix: donut-test
 
 services:
+  db:
+    image: healthcheck/postgres:alpine
+    volumes:
+      - db:/data
+    environment:
+      - PGDATA=/data
+      - POSTGRES_USER=donut
+      - POSTGRES_PASSWORD=d0nut
+    ports:
+      - "5434:5432"
   fedora:
     image: nulib/fcrepo4
     volumes:
-      - fedora-test:/data
+      - fedora:/data
     ports:
       - "8986:8080"
     healthcheck:
@@ -22,7 +35,7 @@ services:
     ports:
       - "8985:8983"
     volumes:
-      - solr-test:/opt/solr/server/solr/mycores
+      - solr:/opt/solr/server/solr/mycores
       - ./solr:/solr_config
     entrypoint:
       - docker-entrypoint.sh
@@ -37,9 +50,9 @@ services:
   minio:
     image: minio/minio
     ports:
-      - "9010:9000"
+      - "9002:9000"
     volumes:
-      - minio-test:/data
+      - minio:/data
     environment:
       MINIO_ACCESS_KEY: minio-test-key
       MINIO_SECRET_KEY: minio-test-secret
@@ -50,7 +63,7 @@ services:
   redis:
     image: redis:alpine
     ports:
-      - "6380:6379"
+      - "6381:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,24 @@
-version: '3'
+version: '3.4'
 
 volumes:
+  db:
   fedora:
   solr:
   minio:
 
+x-container-prefix: donut-dev
+
 services:
+  db:
+    image: healthcheck/postgres:alpine
+    volumes:
+      - db:/data
+    environment:
+      - PGDATA=/data
+      - POSTGRES_USER=donut
+      - POSTGRES_PASSWORD=d0nut
+    ports:
+      - "5433:5432"
   fedora:
     image: nulib/fcrepo4
     volumes:
@@ -37,7 +50,7 @@ services:
   cantaloupe:
     image: nulib/cantaloupe
     ports:
-      - "8182:8182"
+      - "8183:8182"
     volumes:
       - ./tmp/derivatives:/var/lib/cantaloupe/images
     healthcheck:
@@ -48,7 +61,7 @@ services:
   minio:
     image: minio/minio
     ports:
-      - "9000:9000"
+      - "9001:9000"
     volumes:
       - minio:/data
     environment:
@@ -61,7 +74,7 @@ services:
   redis:
     image: redis:alpine
     ports:
-      - "6379:6379"
+      - "6380:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 30s

--- a/lib/docker_controller.rb
+++ b/lib/docker_controller.rb
@@ -4,6 +4,8 @@ class DockerController
   def initialize(config: 'docker-compose.yml', cleanup: false)
     @dc = Docker::Compose::Session.new(dir: Rails.root, file: config)
     @cleanup = cleanup
+    spec = YAML.safe_load(File.read(Rails.root.join(config)))
+    ENV['COMPOSE_PROJECT_NAME'] = spec['x-container-prefix'] if spec.key?('x-container-prefix')
   end
 
   def status

--- a/lib/donut/database_creator.rb
+++ b/lib/donut/database_creator.rb
@@ -1,0 +1,13 @@
+module Donut
+  module DatabaseCreator
+    module_function
+
+    include ActiveRecord::Tasks
+
+    def create_only_current!
+      config = ActiveRecord::Base.configurations[Rails.env]
+      DatabaseTasks.create config
+      ActiveRecord::Base.establish_connection(Rails.env.to_sym)
+    end
+  end
+end

--- a/lib/tasks/add_admin_user.rake
+++ b/lib/tasks/add_admin_user.rake
@@ -1,6 +1,0 @@
-desc 'Add admin role to last user'
-task add_admin_role: :environment do
-  u = User.last
-  puts "Adding admin role to user #{u}"
-  u.roles << Role.first_or_create(name: 'admin') unless u.admin?
-end

--- a/lib/tasks/s3_tasks.rake
+++ b/lib/tasks/s3_tasks.rake
@@ -2,9 +2,9 @@
 namespace :s3 do
   desc 'Create all configured S3 buckets'
   task create_buckets: :environment do
-    client = Aws::S3::Client.new
     Settings.aws.buckets.to_h.values.each do |bucket|
-      client.create_bucket(bucket: bucket)
+      bucket = Aws::S3::Bucket.new(bucket)
+      bucket.create unless bucket.exists?
     end
   end
 
@@ -15,7 +15,7 @@ namespace :s3 do
     Dir.glob('**/*').each do |file|
       next if File.directory?(file)
       obj = s3.bucket(Settings.aws.buckets.batch).object(file)
-      obj.upload_file(file)
+      obj.upload_file(file) unless obj.exists?
     end
   end
 


### PR DESCRIPTION
More improvements to the dockerized dev environment, including:

- a `rake donut:seed` task that:
  - creates/migrates the DB
  - creates the collection types
  - creates the default admin set
  - imports the default workflows
  - activates the default workflows
  - sets up and populates the S3 bucket
  - creates a user and makes it an admin (if `ADMIN_USER` and `ADMIN_EMAIL` are specified)
- a postgres container and the `config/database.yaml` to use it
- a workaround for a stupid ActiveRecord behavior that wants to create the test database in dev mode, which doesn't work with our dockerized environment