### PR TITLE
handle batch level validation failure

### DIFF
--- a/app/batch/importer/csv_parser.rb
+++ b/app/batch/importer/csv_parser.rb
@@ -1,6 +1,8 @@
 module Importer
   # rubocop:disable Metrics/ClassLength
   class CSVParser
+    class ParserError < StandardError
+    end
     include Enumerable
     attr_reader :email
 
@@ -50,7 +52,7 @@ module Importer
         # e.g. For an author, author_type might be 'Person'.
         difference.delete_if { |h| h.match(type_header_pattern) }
 
-        raise "Invalid headers: #{difference.join(', ')}" if difference.present?
+        raise ParserError, "Invalid headers: #{difference.join(', ')}" if difference.present?
 
         validate_header_pairs(row)
         row
@@ -69,7 +71,7 @@ module Importer
             errors << "Invalid headers: '#{header}' column must be immediately followed by '#{field_name}' column."
           end
         end
-        raise errors.join(', ') if errors.present?
+        raise ParserError, errors.join(', ') if errors.present?
       end
       # rubocop:enable Metrics/MethodLength
 

--- a/app/jobs/s3_import_job.rb
+++ b/app/jobs/s3_import_job.rb
@@ -11,8 +11,8 @@ class S3ImportJob < ApplicationJob
     validate_bucket!
     validate_csv_file!
 
-    size = Importer::CSVImporter.new(csv_file, csv_resource, job_id).import_all
-    Rails.logger.info("#{size} records imported from #{s3_url}")
+    Importer::CSVImporter.new(csv_file, csv_resource, job_id).import_all
+    Rails.logger.info("Batch complete. Records imported from #{s3_url}")
   end
 
   private

--- a/spec/batch/importer/csv_parser_spec.rb
+++ b/spec/batch/importer/csv_parser_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Importer::CSVParser do
       let(:headers) { ['something bad', 'title'] }
 
       it 'raises an error' do
-        expect { parsed_headers }.to raise_error(RuntimeError, 'Invalid headers: something bad')
+        expect { parsed_headers }.to raise_error(Importer::CSVParser::ParserError)
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Importer::CSVParser do
       let(:headers) { %w[note note_type rights_holder_type rights_holder_type rights_holder title] }
 
       it 'raises an error' do
-        expect { parsed_headers }.to raise_error(RuntimeError, "Invalid headers: 'note_type' column " \
+        expect { parsed_headers }.to raise_error(Importer::CSVParser::ParserError, "Invalid headers: 'note_type' column " \
           "must be immediately followed by 'note' column., Invalid headers: " \
           "'rights_holder_type' column must be immediately followed by " \
           "'rights_holder' column.")


### PR DESCRIPTION
* If there is a failure at the batch level during header validation, raise and rescue a custom error
* UI will display a batch item error for row number zero with details about the validation problem. 
* The Job does not retry