### PR TITLE
fix comma first character in data row bug

### DIFF
--- a/app/batch/importer/csv_parser.rb
+++ b/app/batch/importer/csv_parser.rb
@@ -7,7 +7,7 @@ module Importer
     attr_reader :email
 
     def initialize(content)
-      @content = content.sub(/^\W+/, '')
+      @content = content.sub(/\A\W+/, '')
       # Read email from first row
       read_email
     end


### PR DESCRIPTION
Replaces `^` with `\A`

* The `^` seems to remove problem characters at the start of all lines, using `\A` just removes from the start of the file.  This is causing a problem if the first property in a data row is blank (like a blank accession number) which means the first character in that row is a comma, which is removed and then the data row is off.