### PR TITLE
validates controlled properties in batch contain uris

### DIFF
--- a/app/views/batches/_error_row.html.erb
+++ b/app/views/batches/_error_row.html.erb
@@ -1,5 +1,5 @@
 <tr id="error_<%= index %>" class="collapse <%= status_context(item.status) %>">
   <td colspan="4" style="padding-left: 2em;">
-    <%= error_collector(item.error) %>
+    <%= error_collector(item.error).html_safe %>
   </td>
 </tr>


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/480

* makes sure spreadsheet values for properties defined as controlled on the Image model are uri's
* fixes bug where `<br />` in the batch_item's error_row is escaped and displayed as string
* updates spec in batch_item_spec.rb for new validation