### PR TITLE
Add smart, configurable retry to Ldp and RSolr

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem 'ezid-client'
 gem 'hydra-role-management'
 gem 'omniauth-openam'
 
+gem 'retryable'
+
 gem 'rubyzip', require: 'zip'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1221,6 +1221,7 @@ GEM
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
     retriable (3.1.1)
+    retryable (3.0.1)
     rsolr (2.1.0)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
@@ -1421,6 +1422,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rails (~> 5.1.1)
   redis-rails
+  retryable
   rsolr (>= 1.0)
   rspec-activemodel-mocks (~> 1.0)
   rspec-rails

--- a/config/initializers/retry.rb
+++ b/config/initializers/retry.rb
@@ -1,0 +1,6 @@
+require 'ldp'
+require 'rsolr'
+require 'donut/retry'
+
+RSolr::Client.include(Donut::Retry::Solr)
+Ldp::Client.include(Donut::Retry::Ldp)

--- a/lib/donut/retry.rb
+++ b/lib/donut/retry.rb
@@ -77,9 +77,12 @@ module Donut
       end
 
       def self.included(mod)
-        mod.alias_method :_execute, :execute
-        mod.define_method :execute do |*args|
-          Donut::Retry.with_retries(:solr) { _execute(*args) }
+        mod.module_eval do
+          alias_method :_execute, :execute
+
+          define_method :execute do |*args|
+            Donut::Retry.with_retries(:solr) { _execute(*args) }
+          end
         end
       end
     end

--- a/lib/donut/retry.rb
+++ b/lib/donut/retry.rb
@@ -1,0 +1,78 @@
+module Donut
+  module Retry
+    class << self
+      def tries=(n)
+        [:ldp, :solr].each { |context| Retryable.configuration.contexts[context][:tries] = n }
+      end
+
+      def log_retries(tag, retries, exception)
+        return if retries.zero?
+        Rails.logger.warn("#{tag}: Retry ##{retries}. Reason: #{exception.class.name}: '#{exception.message}'")
+      end
+
+      def backoff_handler
+        ->(n) { (n * 0.5) + (n * rand) }
+      end
+
+      def retry(context)
+        Retryable.with_context(context) do |retries, last_exception|
+          Retry.log_retries(context.to_s.upcase, retries, last_exception)
+          yield
+        end
+      end
+
+      def configure(mod)
+        Retryable.configure do |config|
+          config.contexts[mod.name.split(/::/).last.underscore.to_sym] = {
+            tries: 10,
+            on: mod.errors,
+            sleep: backoff_handler
+          }
+        end
+      end
+    end
+
+    module Ldp
+      def self.errors
+        [::Ldp::Error, ::Ldp::HttpError]
+      end
+
+      def head(*args)
+        Donut::Retry.retry(:ldp)  { super(*args) }
+      end
+
+      def get(*args)
+        Donut::Retry.retry(:ldp)  { super(*args) }
+      end
+
+      def delete(*args)
+        Donut::Retry.retry(:ldp)  { super(*args) }
+      end
+
+      def post(*args)
+        Donut::Retry.retry(:ldp)  { super(*args) }
+      end
+
+      def put(*args)
+        Donut::Retry.retry(:ldp)  { super(*args) }
+      end
+
+      def patch(*args)
+        Donut::Retry.retry(:ldp)  { super(*args) }
+      end
+    end
+
+    module Solr
+      def self.errors
+        [RSolr::Error::Http]
+      end
+
+      def execute(*args)
+        Donut::Retry.retry(:solr) { super(*args) }
+      end
+    end
+  end
+end
+
+Donut::Retry.configure(Donut::Retry::Ldp)
+Donut::Retry.configure(Donut::Retry::Solr)

--- a/spec/lib/donut/retry_spec.rb
+++ b/spec/lib/donut/retry_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe Donut::Retry do
+  let(:log_spy) { instance_spy('logger') }
+
+  before do
+    allow(Rails).to receive(:logger).and_return(log_spy)
+  end
+
+  context 'class methods' do
+    it 'does not log the first try' do
+      expect(log_spy).not_to have_received(:warn)
+      described_class.log_retries('TEST', 0, nil)
+    end
+
+    it 'logs retries' do
+      described_class.log_retries('TEST', 1, StandardError.new('Exception Message'))
+      expect(log_spy).to have_received(:warn).with("TEST: Retry #1. Reason: StandardError: 'Exception Message'")
+    end
+
+    it 'provides a backoff handler' do
+      expect(described_class.backoff_handler).to be_a(Proc)
+      100.times do |i|
+        low = i / 2.0
+        expect(described_class.backoff_handler.call(i)).to be_between(low, low + i)
+      end
+    end
+  end
+
+  context 'modules' do
+    before do
+      class LdpTest < ActiveFedora::Base
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :LdpTest)
+    end
+
+    describe Donut::Retry::Ldp do
+      before do
+        stub_request(:any, %r{/rest/})
+          .to_return(status: 503).times(2).then
+          .to_return(status: 201, body: 'http://foo.org/test/12345')
+      end
+
+      it 'retries twice' do
+        expect(LdpTest.new.ldp_source.create).to be_a(Ldp::Resource)
+        expect(log_spy).to have_received(:warn).with(/LDP: Retry #[12]/).exactly(2).times
+      end
+    end
+
+    describe Donut::Retry::Solr do
+      before do
+        stub_request(:post, %r{/solr/})
+          .to_return(status: 503).times(2).then
+          .to_return(status: 200, body: '{}')
+      end
+
+      it 'retries twice' do
+        expect(LdpTest.new(id: '12345').update_index).to be_a(Hash)
+        expect(log_spy).to have_received(:warn).with(/SOLR: Retry #[12]/).exactly(2).times
+      end
+    end
+  end
+end


### PR DESCRIPTION
Monkeypatches `Ldp::Client` and `RSolr::Client` to wrap their web service calls in [Retryable](http://rdoc.info/gems/retryable) blocks