### PR TITLE
Refactor add_admin_role rake task to use env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ $ export PROCESS_ACTIVE_ELASTIC_JOBS=true
 
 1.  Run the development servers with `rake docker:dev:up` (or `daemon`) and `rails s`
 1.  Go to http://devbox.library.northwestern.edu/ and login with OpenAM
-1.  To make the last user who logged in (you) and admin, run `rake add_admin_role`
+1.  To make the user who logged in an admin, run `rake donut:add_admin_role ADMIN_USER[your NetID]`
 1.  Go to http://devbox.library.northwestern.edu/admin/workflow_roles and grant workflow roles if needed

--- a/lib/tasks/donut.rake
+++ b/lib/tasks/donut.rake
@@ -8,11 +8,17 @@ unless Rails.env.production?
       t.rspec_opts = ['--color', '--backtrace']
     end
 
-    desc 'Add admin role to last user'
+    desc 'Add admin role to the ENV[\'ADMIN_USER\']'
     task add_admin_role: :environment do
-      u = User.last
-      puts "Adding admin role to user #{u}"
-      u.roles << Role.first_or_create(name: 'admin') unless u.admin?
+      if ENV['ADMIN_USER']
+        u = User.find_by(username: ENV['ADMIN_USER'])
+        if u.admin?
+          puts "#{u} already an admin"
+        else
+          puts "Adding admin role to user #{u}"
+          u.roles << Role.first_or_create(name: 'admin')
+        end
+      end
     end
 
     desc 'Seed the development environment'


### PR DESCRIPTION
Run `rake donut:add_admin_role ADMIN_USER[your NetID]` or `rake donut:seed ADMIN_USER=[your NetID] ADMIN_EMAIL=[your email]`