### PR TITLE
Support FIFO queues in ActiveJob

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,3 @@
 class ApplicationJob < ActiveJob::Base
+  queue_as Hyrax.config.ingest_queue_name
 end

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,6 +1,4 @@
-class CharacterizeJob < Hyrax::ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
-
+class CharacterizeJob < ApplicationJob
   # Characterizes the file at 'filepath' if available, otherwise, pulls a copy from the repository
   # and runs characterization on that file.
   # @param [FileSet] file_set

--- a/app/jobs/create_pyramid_tiff_job.rb
+++ b/app/jobs/create_pyramid_tiff_job.rb
@@ -1,8 +1,6 @@
 require 'ruby-vips'
 
 class CreatePyramidTiffJob < ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
-
   # @param [FileSet] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -195,7 +195,7 @@ Hyrax.config do |config|
   # config.fits_message_length = 5
 
   # ActiveJob queue to handle ingest-like jobs
-  # config.ingest_queue_name = :default
+  config.ingest_queue_name = Settings.aws&.queues&.ingest || :default
 
   ## Attributes for the lock manager which ensures a single process/thread is mutating a ore:Aggregation at once.
   # How many times to retry to acquire the lock before raising UnableToAcquireLockError

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,11 +1,11 @@
 localstack:
   sqs: false
   port_offset: 100
-active_job_queue:
-  url: http://localhost:4676/queue/donut
 aws:
   buckets:
     uploads: dev-uploads
     batch: dev-batch
+  queues:
+    ingest: donut.fifo
 iiif:
   endpoint: http://localhost:8183/iiif/2/

--- a/lib/active_job/queue_adapters/better_active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/better_active_elastic_job_adapter.rb
@@ -6,13 +6,14 @@ module ActiveJob
       class << self
         private
 
-          # Upstream dynamically calculated queue urls for each job; we'd rather
-          # route jobs into a pre-determined queue url instead.
-          def queue_url(*_)
-            if Settings.active_job_queue.url
-              Settings.active_job_queue.url
-            else
-              super
+          def build_message(queue_name, serialized_job, timestamp)
+            super.tap do |result|
+              if queue_name.ends_with?('.fifo')
+                job = JSON.parse(serialized_job)
+                id_argument = job['arguments'].find { |arg| arg.is_a?(Hash) && arg.keys.first == '_aj_globalid' }
+                group_id = id_argument.nil? ? job['arguments'].first.to_s : id_argument['_aj_globalid']
+                result[:message_group_id] = group_id
+              end
             end
           end
       end

--- a/spec/lib/active_job/queue_adapters/better_active_elastic_job_adapter_spec.rb
+++ b/spec/lib/active_job/queue_adapters/better_active_elastic_job_adapter_spec.rb
@@ -1,23 +1,42 @@
-require 'active_job/queue_adapters/better_active_elastic_job_adapter'
+require 'rails_helper'
 
 RSpec.describe ActiveJob::QueueAdapters::BetterActiveElasticJobAdapter do
-  let(:queue_url) { 'http://example.com/queue/url' }
-  let(:aws_sqs_client) { instance_double(Aws::SQS::Client) }
-  let(:job) { ApplicationJob.new }
+  let(:model)   { FakeModel.new(id: 'abcdef') }
+  let(:job)     { JSON.dump(TestJob.new(model).serialize) }
+  let(:message) { described_class.send(:build_message, queue_name, job, Time.current) }
 
   before do
-    allow(Settings.active_job_queue).to receive(:url).and_return(queue_url)
+    class FakeModel < ActiveFedora::Base
+      include GlobalID::Identification
+    end
+
+    class TestJob < ApplicationJob
+      queue_as queue_name
+    end
+
     Rails.application.config.active_elastic_job.secret_key_base = Rails.application.secrets[:secret_key_base]
-    allow(described_class).to receive(:aws_sqs_client).and_return(aws_sqs_client)
+
+    allow(described_class).to receive(:queue_url).and_return("http://localhost:4567/queues/#{queue_name}")
   end
 
-  describe '#enqueue' do
-    it 'uses the configured queue' do
-      allow(aws_sqs_client).to receive(:send_message) do |msg|
-        expect(msg[:queue_url]).to eq queue_url
-      end
+  after do
+    Object.send(:remove_const, :TestJob)
+    Object.send(:remove_const, :FakeModel)
+  end
 
-      described_class.enqueue job
+  describe 'regular job' do
+    let(:queue_name) { 'queued' }
+
+    it 'does not include a message_group_id' do
+      expect(message).not_to have_key(:message_group_id)
+    end
+  end
+
+  describe 'FIFO job' do
+    let(:queue_name) { 'queued.fifo' }
+
+    it 'includes a message_group_id' do
+      expect(message).to have_key(:message_group_id)
     end
   end
 end

--- a/spec/support/active_elastic_job_config.rb
+++ b/spec/support/active_elastic_job_config.rb
@@ -1,0 +1,11 @@
+require 'active_job/queue_adapters/better_active_elastic_job_adapter'
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    ActiveJob::QueueAdapters::BetterActiveElasticJobAdapter.send(:instance_variable_set, :@aws_credentials, Aws::SharedCredentials.new)
+  end
+
+  config.after(:suite) do
+    ActiveJob::QueueAdapters::BetterActiveElasticJobAdapter.send(:instance_variable_set, :@aws_credentials, nil)
+  end
+end


### PR DESCRIPTION
Make the changes to `ActiveJob::QueueAdapters::BetterActiveElasticJobAdapter` required to support AWS SQS FIFO queues