### PR TITLE
validate edtf format for date_created and index display value

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'omniauth-openam'
 
 gem 'donut-retry', github: 'nulib/donut-retry', branch: 'master'
 
+gem 'edtf'
+gem 'edtf-humanize'
+
 gem 'rubyzip', require: 'zip'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -839,6 +839,11 @@ GEM
     ebnf (1.1.2)
       rdf (>= 2.2, < 4.0)
       sxp (~> 1.0)
+    edtf (3.0.4)
+      activesupport (>= 3.0, < 6.0)
+    edtf-humanize (0.0.7)
+      activesupport (>= 4, < 6)
+      edtf (>= 2.3, < 4)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubi (1.7.1)
@@ -1417,6 +1422,8 @@ DEPENDENCIES
   docker-compose
   docker-stack
   donut-retry!
+  edtf
+  edtf-humanize
   exiftool_vendored
   ezid-client
   factory_bot_rails

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -117,7 +117,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('language_label', :stored_searchable), label: 'Language', link_to_search: solr_name('language_label', :facetable)
     config.add_index_field solr_name('date_uploaded', :stored_sortable, type: :date), itemprop: 'datePublished', helper_method: :human_readable_date
     config.add_index_field solr_name('date_modified', :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
-    config.add_index_field solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
+    config.add_index_field solr_name('date_created_display', :stored_searchable), itemprop: 'dateCreated', label: 'Date Created'
     config.add_index_field solr_name('rights', :stored_searchable), helper_method: :license_links
     config.add_index_field solr_name('resource_type', :stored_searchable), label: 'Resource Type', link_to_search: solr_name('resource_type', :facetable)
     config.add_index_field solr_name('bibliographic_citation', :stored_searchable), label: 'Citation'
@@ -183,7 +183,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('language_label', :stored_searchable), label: 'Language'
     config.add_show_field solr_name('date_uploaded', :stored_searchable)
     config.add_show_field solr_name('date_modified', :stored_searchable)
-    config.add_show_field solr_name('date_created', :stored_searchable)
+    config.add_show_field solr_name('date_created_display', :stored_searchable), label: 'Date Created Display'
     config.add_show_field solr_name('rights', :stored_searchable)
     config.add_show_field solr_name('resource_type', :stored_searchable), label: 'Resource Type'
     config.add_show_field solr_name('format', :stored_searchable)
@@ -311,6 +311,15 @@ class CatalogController < ApplicationController
 
     config.add_search_field('date_created') do |field|
       solr_name = solr_name('created', :stored_searchable)
+      field.solr_local_parameters = {
+        qf: solr_name,
+        pf: solr_name
+      }
+    end
+
+    config.add_search_field('date_created_display') do |field|
+      field.label = 'Date Created Display'
+      solr_name = solr_name('date_created_display', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name

--- a/app/indexers/image_indexer.rb
+++ b/app/indexers/image_indexer.rb
@@ -9,10 +9,10 @@ class ImageIndexer < Hyrax::WorkIndexer
   # this behavior
   include Hyrax::IndexesLinkedMetadata
 
-  # Uncomment this block if you want to add custom indexing behavior:
-  # def generate_solr_document
-  #  super.tap do |solr_doc|
-  #    solr_doc['my_custom_field_ssim'] = object.my_custom_property
-  #  end
-  # end
+  # Custom indexing behavior:
+  def generate_solr_document
+    super.tap do |solr_doc|
+      solr_doc['date_created_display_tesim'] = object.date_created.map { |d| Date.edtf(d).humanize }
+    end
+  end
 end

--- a/app/models/concerns/edtf_date_validator.rb
+++ b/app/models/concerns/edtf_date_validator.rb
@@ -1,0 +1,11 @@
+class EdtfDateValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    errors = value.reject(&:empty?).select { |date| invalid?(date) }
+    return if errors.to_a.empty?
+    record.errors.add(attribute, "Invalid EDTF #{'date'.pluralize(errors.size)}: #{errors.join(',')}")
+  end
+
+  def invalid?(value)
+    Date.edtf(value).nil?
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -12,6 +12,7 @@ class Image < ActiveFedora::Base
   validates :title, presence: { message: 'Your work must have a title.' }
   validates :accession_number, presence: { message: 'Accession number is required.' }, accession_number: true, on: :create
   validates :resource_type, resource_type: true
+  validates :date_created, presence: { message: 'Date created is required' }, edtf_date: true
 
   after_save do
     ArkMintingService.mint_identifier_for(self) if ark.nil?

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -60,6 +60,10 @@ class SolrDocument
   attribute :sculptor_label, Solr::Array, solr_name('sculptor_label')
   attribute :sponsor_label, Solr::Array, solr_name('sponsor_label')
 
+  def date_created_display
+    fetch(Solrizer.solr_name('date_created_display', :stored_searchable), [])
+  end
+
   def abstract
     fetch(Solrizer.solr_name('abstract', :stored_searchable), [])
   end

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -3,7 +3,7 @@
 module Hyrax
   class ImagePresenter < Hyrax::WorkShowPresenter
     TERMS = [:abstract, :accession_number, :alternate_title, :ark,
-             :bibliographic_citation, :call_number, :caption, :catalog_key, :contributor_label, :creator_label,
+             :bibliographic_citation, :call_number, :caption, :catalog_key, :contributor_label, :creator_label, :date_created_display,
              :genre_label, :subject_geographical_label, :subject_topical_label, :subject_temporal, :language_label,
              :provenance, :physical_description_material, :physical_description_size, :rights_holder,
              :style_period_label, :technique_label, :nul_creator, :nul_contributor, :nul_use_statement,

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -11,7 +11,7 @@
 <%= presenter.attribute_to_html(:contributor_label, render_as: :faceted, label: 'Contributor') %>
 <%= presenter.attribute_to_html(:creator_label, render_as: :faceted, label: 'Creator') %>
 <%= presenter.attribute_to_html(:creator_attribution) %>
-<%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim') %>
+<%= presenter.attribute_to_html(:date_created_display, render_as: :linked, search_field: 'date_created_display_tesim', label: 'Date Created') %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link) %>
 <%= presenter.attribute_to_html(:folder_name) %>
 <%= presenter.attribute_to_html(:folder_number) %>

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     call_number 'W107.8:Am6'
     caption ['This is the caption seen on the image']
     catalog_key ['9943338434202441']
+    date_created ['197x']
     genre ['Postmodern']
     provenance ['The example provenance']
     physical_description_size ['Wood 6cm x 7cm']

--- a/spec/indexers/image_indexer_spec.rb
+++ b/spec/indexers/image_indexer_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ImageIndexer do
+  describe '#generate_solr_document' do
+    let(:solr_doc) { described_class.new(image).generate_solr_document }
+
+    context 'with an image' do
+      let(:image) { FactoryBot.build(:image, date_created: ['1987~', 'uuuu']) }
+
+      it 'indexes the human readable/display for date_created' do
+        expect(solr_doc['date_created_display_tesim']).to match_array(['circa 1987', 'unknown'])
+      end
+    end
+  end
+end

--- a/spec/models/concerns/edtf_date_validator_spec.rb
+++ b/spec/models/concerns/edtf_date_validator_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EdtfDateValidator do
+  before do
+    class TestWork < ActiveFedora::Base
+      validates :date_created, edtf_date: true
+
+      property :date_created, predicate: ::RDF::Vocab::DC.created, multiple: true do |index|
+        index.as :stored_searchable
+      end
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :TestWork)
+  end
+
+  it 'fails with an invalid edtf date' do
+    invalid_date_work = TestWork.create(date_created: ['notadate'])
+
+    expect(invalid_date_work).to be_invalid
+  end
+
+  it 'returns an error message' do
+    invalid_date_work = TestWork.create(date_created: ['notadate'])
+
+    expect(invalid_date_work.errors[:date_created].first).to include 'notadate'
+  end
+
+  it 'succeeds with a blank date' do
+    no_date = TestWork.create(date_created: [''])
+
+    expect(no_date).to be_valid
+  end
+
+  it 'succeeds with a valid edtf season date' do
+    work_season = TestWork.create(date_created: ['1975-22'])
+
+    expect(work_season).to be_valid
+  end
+
+  it 'succeeds with a valid edtf interval date' do
+    work_interval = TestWork.create(date_created: ['1981/1985'])
+
+    expect(work_interval).to be_valid
+  end
+
+  it 'succeeds with a valid edtf set date' do
+    work_set = TestWork.create(date_created: ['[1888, 1889, 1891]'])
+
+    expect(work_set).to be_valid
+  end
+
+  it 'succeeds with a valid edtf unknown date' do
+    work_unknown = TestWork.create(date_created: ['uuuu'])
+
+    expect(work_unknown).to be_valid
+  end
+
+  it 'succeeds with a valid edtf century date' do
+    work_century = TestWork.create(date_created: ['19xx'])
+
+    expect(work_century).to be_valid
+  end
+end


### PR DESCRIPTION
Fixes: https://github.com/nulib/next-generation-repository/issues/342

* validates (batch and UI) that there is at least one date_created value present, and that the values are in edtf format
* indexes the humanized/display version as `date_created_display_tesim` for use by the front end/UI


Notes: 
This is affected by this bug: https://github.com/nulib/next-generation-repository/issues/486 where you receive an error if you try to correct and resubmit a failed validation in the UI. We're not sure yet whether this is a Hyrax or Donut bug. Until we can address this, the workaround is to make sure you get the format correct first time around. Batch should work fine.