### PR TITLE
adds accession_number and id to all_fields for search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -256,7 +256,7 @@ class CatalogController < ApplicationController
       all_names = config.show_fields.values.map(&:field).join(' ')
       title_name = solr_name('title', :stored_searchable)
       field.solr_parameters = {
-        qf: "#{all_names} file_format_tesim all_text_timv",
+        qf: "#{all_names} file_format_tesim all_text_timv accession_number_tesim id",
         pf: title_name.to_s
       }
     end


### PR DESCRIPTION
Fixes  https://github.com/nulib/next-generation-repository/issues/485

* Allow users to locate works by entering id or accession number into search box