### PR TITLE
index iiif path for collection thumbnail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@
 # Ignore public uploads directory
 /public/uploads
 
+# Ignore branding directory
+/public/branding
+
 # MAC OS
 .DS_Store
 

--- a/app/indexers/donut/collection_indexer.rb
+++ b/app/indexers/donut/collection_indexer.rb
@@ -1,0 +1,19 @@
+module Donut
+  module CollectionIndexer
+    def generate_solr_document
+      super.tap do |solr_doc|
+        if object.thumbnail_id.present?
+          solr_doc['thumbnail_iiif_url_ss'] = thumbnail_iiif_url
+        end
+      end
+    end
+
+    private
+
+      def thumbnail_iiif_url
+        file_set = ::FileSet.find(object.thumbnail_id)
+        file_id = file_set.original_file.id.split(%r{/files/}).last
+        IiifDerivativeService.resolve(file_id).to_s
+      end
+  end
+end

--- a/config/initializers/donut_collection_indexer.rb
+++ b/config/initializers/donut_collection_indexer.rb
@@ -1,0 +1,1 @@
+Hyrax::CollectionIndexer.include(Donut::CollectionIndexer)

--- a/spec/indexers/donut/collection_indexer_spec.rb
+++ b/spec/indexers/donut/collection_indexer_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe Donut::CollectionIndexer do
+  let(:indexer) { TestIndexer.new(collection) }
+  let(:collection) { build(:collection, attributes) }
+  let(:iiif_url) { 'http://localhost:8183/iiif/2/f8%2F6e%2Fb9%2Fd5%2F-9%2F10%2Fb-%2F4c%2F7b%2F-8%2F10%2F5-%2F5a%2Fd0%2Fa2%2F05%2Ff4%2Fe9' }
+  let(:doc) do
+    {
+      'thumbnail_iiif_url_ss' => iiif_url
+    }
+  end
+
+  before do
+    class TestIndexer < Hydra::PCDM::CollectionIndexer
+      include Donut::CollectionIndexer
+
+      attr_reader :object
+
+      def initialize(collection)
+        @object = collection
+      end
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :TestIndexer)
+  end
+
+  describe '#generate_solr_document' do
+    before do
+      allow(indexer).to receive(:thumbnail_iiif_url).and_return(iiif_url)
+    end
+
+    context 'with thumbnail_id present' do
+      subject(:solr_doc) { indexer.generate_solr_document }
+
+      let(:attributes) { { thumbnail_id: 'yes' } }
+
+      it 'has the iiif thumbnail url' do
+        expect(solr_doc).to match a_hash_including(doc)
+      end
+    end
+
+    context 'without thumbnail_id present' do
+      subject(:solr_doc) { indexer.generate_solr_document }
+
+      let(:attributes) { {} }
+
+      it 'does not have the iiif thumbnail url' do
+        expect(solr_doc).not_to include('thumbnail_iiif_url_ss')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes: https://github.com/nulib/next-generation-repository/issues/504

* Indexes the iiif url for the collection thumbnail as `thumbnail_iiif_url_ss`