### PR TITLE
update licenses to Creative Commons 4.0

### DIFF
--- a/config/authorities/licenses.yml
+++ b/config/authorities/licenses.yml
@@ -1,22 +1,22 @@
 terms:
     - id: http://creativecommons.org/licenses/by/3.0/us/
       term: Attribution 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-sa/3.0/us/
       term: Attribution-ShareAlike 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-nc/3.0/us/
       term: Attribution-NonCommercial 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-nd/3.0/us/
       term: Attribution-NoDerivs 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-nc-nd/3.0/us/
       term: Attribution-NonCommercial-NoDerivs 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/licenses/by-nc-sa/3.0/us/
       term: Attribution-NonCommercial-ShareAlike 3.0 United States
-      active: true
+      active: false
     - id: http://creativecommons.org/publicdomain/mark/1.0/
       term: Public Domain Mark 1.0
       active: true
@@ -25,4 +25,22 @@ terms:
       active: true
     - id: http://www.europeana.eu/portal/rights/rr-r.html
       term: All rights reserved
+      active: false
+    - id: https://creativecommons.org/licenses/by/4.0/
+      term: Attribution 4.0 International
+      active: true
+    - id: https://creativecommons.org/licenses/by-sa/4.0/
+      term: Attribution-ShareAlike 4.0 International
+      active: true
+    - id: https://creativecommons.org/licenses/by-nc/4.0/
+      term: Attribution-NonCommercial 4.0 International
+      active: true
+    - id: https://creativecommons.org/licenses/by-nd/4.0/
+      term: Attribution-NoDerivatives 4.0 International
+      active: true
+    - id: https://creativecommons.org/licenses/by-nc-nd/4.0/
+      term: Attribution-NonCommercial-NoDerivatives 4.0 International
+      active: true
+    - id: https://creativecommons.org/licenses/by-nc-sa/4.0/
+      term: Attribution-NonCommercial-ShareAlike 4.0 International
       active: true

--- a/spec/models/concerns/license_validator_spec.rb
+++ b/spec/models/concerns/license_validator_spec.rb
@@ -22,8 +22,14 @@ RSpec.describe LicenseValidator do
     expect(invalid_license_work).to be_invalid
   end
 
+  it 'fails when an inactive license is found' do
+    invalid_license_work = TestWork.create(license: ['http://creativecommons.org/licenses/by/3.0/us/'])
+
+    expect(invalid_license_work).to be_invalid
+  end
+
   it 'succeeds when valid license is found' do
-    valid_license_work = TestWork.create(license: ['http://creativecommons.org/licenses/by/3.0/us/'])
+    valid_license_work = TestWork.create(license: ['https://creativecommons.org/licenses/by-nc-sa/4.0/'])
 
     expect(valid_license_work).to be_valid
   end


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/503

* Adds new Creative Commons 4.0 licenses
* Sets outdated licenses to inactive