### PR TITLE
handle and display malformed csv error to user

### DIFF
--- a/app/batch/importer/csv_importer.rb
+++ b/app/batch/importer/csv_importer.rb
@@ -13,6 +13,7 @@ module Importer
 
     # @return [Integer] count of objects created
     def import_all
+      return if parser.nil?
       @batch = Batch.create(
         submitter: parser.email,
         job_id: @job_id,
@@ -32,6 +33,14 @@ module Importer
 
       def parser
         @parser ||= CSVParser.new(@csv)
+      rescue CSV::MalformedCSVError => error
+        @batch = Batch.create(
+          submitter: 'unknown',
+          job_id: @job_id,
+          original_filename: @s3_resource.key
+        )
+        create_error_row(error)
+        return nil
       end
 
       def s3_url

--- a/spec/batch/importer/csv_importer_spec.rb
+++ b/spec/batch/importer/csv_importer_spec.rb
@@ -9,7 +9,22 @@ RSpec.describe Importer::CSVImporter do
   let(:csv_resource) { Aws::S3::Object.new(client: Aws::S3::Client.new, bucket_name: bucket, key: csv_file_key) }
   let(:job_id) { 'e5942432-cfd1-46f0-ba44-67d5fdd2b6e0' }
 
-  context 'batch import' do
+  context 'batch import with malformed csv file' do
+    let(:importer) { described_class.new(csv, csv_resource, job_id) }
+    let(:csv_file_key) { 'malformed.csv' }
+    let(:csv) { Aws::S3::Client.new.get_object(bucket: bucket, key: csv_file_key).body.read }
+    let(:csv_resource) { Aws::S3::Object.new(client: Aws::S3::Client.new, bucket_name: bucket, key: csv_file_key) }
+
+    describe '.import_all' do
+      it 'creates one batch item with the error' do
+        importer.import_all
+        expect(BatchItem.first.status).to eq('error')
+        expect(BatchItem.count).to eq(1)
+      end
+    end
+  end
+
+  context 'successful batch import' do
     let(:importer) { described_class.new(csv, csv_resource, job_id) }
     let(:collection_factory) { instance_double('CollectionFactory', valid?: true) }
     let(:image_factory) { instance_double('ImageFactory', valid?: true) }

--- a/spec/fixtures/csv/malformed.csv
+++ b/spec/fixtures/csv/malformed.csv
@@ -1,0 +1,3 @@
+﻿david.schober@northwestern.edu,,,,,,,,,
+admin_set_id,accession_number,type,title,date_created,preservation_level,rights_statement,status,file,description
+7a264a8c-8a54-464d-9458-a9b71d4f8a57,0.805167702,Image,"standing at the foot of some steps, leaning against a verandah wall (at the a Club?)",[1902..1906],1,http://rightsstatements.org/vocab/InC/1.0/,Done,files/coffee.jpg,


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/518

• Fixes issues where if a malformed csv file was ingested, it appeared to the user that the batch did not run at all.
• Rescues a `CSV::MalformedCSVError` and creates an error for the batch that will display to the user in the UI. 
• Updated spec for CSVImporter