### PR TITLE
use file_set_ids instead of member_ids

### DIFF
--- a/app/indexers/image_indexer.rb
+++ b/app/indexers/image_indexer.rb
@@ -13,7 +13,7 @@ class ImageIndexer < Hyrax::WorkIndexer
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc['date_created_display_tesim'] = object.date_created.map { |d| Date.edtf(d).humanize }
-      object.member_ids.each do |file_set_id|
+      object.file_set_ids.each do |file_set_id|
         file_set = ::FileSet.find(file_set_id)
         next if file_set.original_file.nil?
         (solr_doc['file_set_iiif_urls_ssim'] ||= []) << IiifDerivativeService.resolve(file_set.original_file.id).to_s

--- a/spec/indexers/image_indexer_spec.rb
+++ b/spec/indexers/image_indexer_spec.rb
@@ -7,7 +7,7 @@ describe ImageIndexer do
     let(:solr_doc) { described_class.new(image).generate_solr_document }
 
     before do
-      allow(image).to receive(:member_ids).and_return([file_set.id])
+      allow(image).to receive(:file_set_ids).and_return([file_set.id])
       allow(FileSet).to receive(:find).with(file_set.id).and_return(file_set)
       allow(IiifDerivativeService).to receive(:resolve).with(file.id).and_return(iiif_url)
     end


### PR DESCRIPTION
* use `object.file_set_ids` instead of `object.member_ids` to identify FileSets as member_ids may contain child works.