### PR TITLE
fixes form validation issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
+  gem 'jasmine'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rubocop', '~> 0.49.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -952,6 +952,12 @@ GEM
     iiif_manifest (0.4.0)
       activesupport (>= 4)
     inflecto (0.0.2)
+    jasmine (2.9.0)
+      jasmine-core (>= 2.9.0, < 3.0.0)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (2.9.1)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -1100,6 +1106,7 @@ GEM
     parser (2.4.0.2)
       ast (~> 2.3)
     pg (0.21.0)
+    phantomjs (2.1.1.0)
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     powerpack (0.1.1)
@@ -1432,6 +1439,7 @@ DEPENDENCIES
   hydra-role-management
   hyrax!
   hyrax-spec (~> 0.2)
+  jasmine
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ And run the test suite in another window:
 $ rake spec
 ```
 
+#### Run the JavaScript tests
+
+Run Jasmine server:
+
+```sh
+$ rake jasmine
+```
+
+Run all tests:
+
+```sh
+$ http://localhost:8888
+```
+
+Run the javascript test suite:
+
+```sh
+$ rake jasmine:ci
+```
+
 ### Running the Batch importer from the command line
 * Run the `rake donut:seed` or `rake s3:setup` rake task to create and populate the S3 bucket
 * Run the importer from the application root directory with the command:

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,4 +21,5 @@
 //= require blacklight/blacklight
 
 //= require_directory .
+//= require nu-template/scripts.js
 //= require hyrax

--- a/app/assets/javascripts/hyrax/save_work/save_work_control.es6
+++ b/app/assets/javascripts/hyrax/save_work/save_work_control.es6
@@ -1,0 +1,171 @@
+//= require hyrax/save_work/validation_service
+
+import { RequiredFields } from './required_fields'
+import { ChecklistItem } from './checklist_item'
+import { UploadedFiles } from './uploaded_files'
+import { DepositAgreement } from './deposit_agreement'
+import VisibilityComponent from './visibility_component'
+import ValidationService from './validation_service'
+
+/**
+ * Polyfill String.prototype.startsWith()
+ */
+if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function(searchString, position){
+      position = position || 0;
+      return this.substr(position, searchString.length) === searchString;
+  };
+}
+
+export default class SaveWorkControl {
+  /**
+   * Initialize the save controls
+   * @param {jQuery} element the jquery selector for the save panel
+   * @param {AdminSetWidget} adminSetWidget the control for the adminSet dropdown
+   */
+  constructor(element, adminSetWidget) {
+    if (element.length < 1) {
+      return
+    }
+    this.element = element
+    this.adminSetWidget = adminSetWidget
+    this.form = element.closest('form')
+    element.data('save_work_control', this)
+    this.activate();
+  }
+
+  /**
+   * Keep the form from submitting (if the return key is pressed)
+   * unless the form is valid.
+   *
+   * This seems to occur when focus is on one of the visibility buttons
+   */
+  preventSubmitUnlessValid() {
+    this.form.on('submit', (evt) => {
+      if (!this.isValid())
+        evt.preventDefault();
+    })
+  }
+
+  /**
+   * Keep the form from being submitted many times.
+   *
+   */
+  preventSubmitIfAlreadyInProgress() {
+    this.form.on('submit', (evt) => {
+      if (this.isValid())
+        this.saveButton.prop("disabled", true);
+    })
+  }
+
+  /**
+   * Keep the form from being submitted while uploads are running
+   *
+   */
+  preventSubmitIfUploading() {
+    this.form.on('submit', (evt) => {
+      if (this.uploads.inProgress) {
+        evt.preventDefault()
+      }
+    })
+  }
+
+
+
+  /**
+   * Is the form for a new object (vs edit an existing object)
+   */
+  get isNew() {
+    return this.form.attr('id').startsWith('new')
+  }
+
+  /*
+   * Call this when the form has been rendered
+   */
+  activate() {
+    if (!this.form) {
+      return
+    }
+    this.requiredFields = new RequiredFields(this.form, () => this.formStateChanged())
+    this.uploads = new UploadedFiles(this.form, () => this.formStateChanged())
+    this.saveButton = this.element.find(':submit')
+    this.depositAgreement = new DepositAgreement(this.form, () => this.formStateChanged())
+    this.requiredMetadata = new ChecklistItem(this.element.find('#required-metadata'))
+    this.requiredFiles = new ChecklistItem(this.element.find('#required-files'))
+    this.requiredAgreement = new ChecklistItem(this.element.find('#required-agreement'))
+    new VisibilityComponent(this.element.find('.visibility'), this.adminSetWidget)
+    this.preventSubmit()
+    this.watchMultivaluedFields()
+    this.formChanged()
+    new ValidationService(this.form, this.isNew)
+  }
+
+  preventSubmit() {
+    this.preventSubmitUnlessValid()
+    this.preventSubmitIfAlreadyInProgress()
+    this.preventSubmitIfUploading()
+  }
+
+  // If someone adds or removes a field on a multivalue input, fire a formChanged event.
+  watchMultivaluedFields() {
+      $('.multi_value.form-group', this.form).bind('managed_field:add', () => this.formChanged())
+      $('.multi_value.form-group', this.form).bind('managed_field:remove', () => this.formChanged())
+  }
+
+  // Called when a file has been uploaded, the deposit agreement is clicked or a form field has had text entered.
+  formStateChanged() {
+    this.saveButton.prop("disabled", !this.isValid());
+  }
+
+  // called when a new field has been added to the form.
+  formChanged() {
+    this.requiredFields.reload();
+    this.formStateChanged();
+  }
+
+  isValid() {
+    // avoid short circuit evaluation. The checkboxes should be independent.
+    let metadataValid = this.validateMetadata()
+    let filesValid = this.validateFiles()
+    let agreementValid = this.validateAgreement(filesValid)
+    return metadataValid && filesValid && agreementValid
+  }
+
+  // sets the metadata indicator to complete/incomplete
+  validateMetadata() {
+    if (this.requiredFields.areComplete) {
+      this.requiredMetadata.check()
+      return true
+    }
+    this.requiredMetadata.uncheck()
+    return false
+  }
+
+  // sets the files indicator to complete/incomplete
+  validateFiles() {
+    if (!this.uploads.hasFileRequirement) {
+      return true
+    }
+    if (!this.isNew || this.uploads.hasFiles) {
+      this.requiredFiles.check()
+      return true
+    }
+    this.requiredFiles.uncheck()
+    return false
+  }
+
+  validateAgreement(filesValid) {
+    if (filesValid && this.uploads.hasNewFiles && this.depositAgreement.mustAgreeAgain) {
+      // Force the user to agree again
+      this.depositAgreement.setNotAccepted()
+      this.requiredAgreement.uncheck()
+      return false
+    }
+    if (!this.depositAgreement.isAccepted) {
+      this.requiredAgreement.uncheck()
+      return false
+    }
+    this.requiredAgreement.check()
+    return true
+  }
+}

--- a/app/assets/javascripts/hyrax/save_work/validation_service.es6
+++ b/app/assets/javascripts/hyrax/save_work/validation_service.es6
@@ -1,0 +1,60 @@
+export default class ValidationService {
+  /**
+   * @param {Form} element
+   */
+  constructor(form, new_work) {
+    this.form = form
+    this.form.on('submit', (event) => { this.checkValidationService(event, new_work) })
+    this.setupAlert()
+    this.readOnlyAccession(new_work)
+  }
+
+  /**
+   * check the validation service before submit
+   *
+   */
+  checkValidationService(event, new_work) {
+      event.preventDefault()
+      this.closeAlert()
+      const url = new_work ? '/validate_new' : '/validate_edit'
+      const data = this.form.serialize()
+
+      fetch(url, {
+        method: 'POST',
+        body: data,
+        headers: new Headers({
+          'Content-Type': 'multipart/form-data'
+        })
+      }).then(res => res.json())
+      .catch(error => console.error('Error:', error))
+      .then(response => {
+        if (response.error) {
+          this.addError(JSON.stringify(response.error))
+          this.form.find(':submit').attr('disabled', false)
+        } else {
+          this.form.unbind('submit').submit()
+        }
+      });
+  }
+
+  readOnlyAccession(new_work) {
+    if (!new_work) {
+      $('#image_accession_number').attr('readonly', true)
+    }
+  }
+
+  setupAlert() {
+    this.form.before('<div id="donut_validation" class="alert alert-danger hidden"></div>')
+  }
+
+  addError(message) {
+    $('#donut_validation').html(message);
+    $('#donut_validation').removeClass('hidden')
+  }
+
+  closeAlert() {
+    if (!$('#donut_validation').hasClass('hidden')) {
+      $('#donut_validation').addClass('hidden')
+    }
+  }
+}

--- a/app/controllers/validation_controller.rb
+++ b/app/controllers/validation_controller.rb
@@ -1,0 +1,39 @@
+class ValidationController < ApplicationController
+  protect_from_forgery with: :null_session
+  before_action :transform_rights_statement
+
+  def validate_new
+    validate(validation_params)
+  end
+
+  def validate_edit
+    validate(transform_edit_params)
+  end
+
+  private
+
+    def validate(attributes)
+      payload = if Donut::ValidationService.valid?(klass: Image, attributes: attributes)
+                  { message: 'Validation Success' }
+                else
+                  { error: Donut::ValidationService.errors(klass: Image, attributes: attributes) }
+                end
+      render json: payload, status: 200
+    end
+
+    def transform_edit_params
+      # give it a dummy accession_number
+      # because 'edit' will find it's own asseccsion as duplicate
+      # but needs a unique one to validate
+      validation_params.except(:accession_number, :permissions_attributes, :version).merge(accession_number: 'INVALID_ACCESSION')
+    end
+
+    def transform_rights_statement
+      return if params[:image][:rights_statement].is_a? Array
+      params[:image][:rights_statement] = [params[:image][:rights_statement]]
+    end
+
+    def validation_params
+      params.require(:image).permit(Hyrax::ImageForm.permitted_params, rights_statement: [])
+    end
+end

--- a/app/models/concerns/accession_number_validator.rb
+++ b/app/models/concerns/accession_number_validator.rb
@@ -1,7 +1,6 @@
 class AccessionNumberValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return unless duplicate?(value)
-    record.errors.add(:base, 'An error occured. Please see details below')
     record.errors.add(attribute, 'Accession number must be unique')
   end
 

--- a/app/models/concerns/preservation_level_validator.rb
+++ b/app/models/concerns/preservation_level_validator.rb
@@ -1,7 +1,6 @@
 class PreservationLevelValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if valid?(value)
-    record.errors.add(:base, 'An error occured. Please see details below')
     record.errors.add(attribute, "Only #{valid_values} are valid preservation level values")
   end
 

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -40,7 +40,6 @@
 <%= presenter.attribute_to_html(:task_number) %>
 <%= presenter.attribute_to_html(:project_cycle, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:nul_creator, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:subject, render_as: :faceted, label: 'NUL Subject') %>
 <%= presenter.attribute_to_html(:provenance) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted, label: 'NUL Subject') %>
 <%= presenter.attribute_to_html(:nul_contributor, render_as: :faceted) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
       format: false,
       constraints: { accession_number: /.+/ }
 
+  post '/validate_new', to: 'validation#validate_new', as: :validate_new
+  patch '/validate_edit', to: 'validation#validate_edit', as: :validate_edit
+
   mount BrowseEverything::Engine => '/browse'
   mount Blacklight::Engine => '/'
 

--- a/lib/tasks/donut.rake
+++ b/lib/tasks/donut.rake
@@ -47,6 +47,7 @@ unless Rails.env.production?
     task :ci do
       Rake::Task['donut:ci:rubocop'].invoke
       Rake::Task['donut:ci:rspec'].invoke
+      Rake::Task['jasmine:ci'].invoke
     end
 
     namespace :ci do

--- a/spec/controllers/validation_controller_spec.rb
+++ b/spec/controllers/validation_controller_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe ValidationController, type: :controller do
+  describe 'POST #validate_new' do
+    context 'with valid attributes' do
+      it 'returns a success message' do
+        post :validate_new, params: { image: FactoryBot.attributes_for(:image) }
+        expect(response.status).to equal(200)
+        expect(response.parsed_body).to eq('{"message":"Validation Success"}')
+      end
+    end
+
+    context 'with invalid attributes' do
+      it 'returns an error message' do
+        post :validate_new, params: { image: FactoryBot.attributes_for(:image).except(:title) }
+        expect(response.status).to equal(200)
+        expect(response.parsed_body).to include('error')
+      end
+    end
+  end
+
+  describe 'POST #validate_edit' do
+    let(:accession_number) { 'abc123' }
+    let(:valid_attributes) do
+      {
+        title: ['the title'],
+        accession_number: accession_number,
+        creator: ['http://creator'],
+        date_created: ['1927'],
+        preservation_level: '1',
+        status: 'Done',
+        rights_statement: ['http://rightsstatements.org/vocab/NKC/1.0/']
+      }
+    end
+    let(:image) { FactoryBot.create(:image, accession_number: accession_number) }
+
+    context 'with valid attributes' do
+      it 'returns a success message' do
+        patch :validate_edit, params: { image: valid_attributes }
+        expect(response.status).to equal(200)
+        expect(response.parsed_body).to eq('{"message":"Validation Success"}')
+      end
+    end
+
+    context 'with invalid attributes' do
+      it 'returns an error message' do
+        patch :validate_edit, params: { image: valid_attributes.except(:title) }
+        expect(response.status).to equal(200)
+        expect(response.parsed_body).to include('error')
+      end
+    end
+  end
+end

--- a/spec/javascripts/helpers/jasmine-jquery.js
+++ b/spec/javascripts/helpers/jasmine-jquery.js
@@ -1,0 +1,841 @@
+/*!
+Jasmine-jQuery: a set of jQuery helpers for Jasmine tests.
+
+Version 2.1.1
+
+https://github.com/velesin/jasmine-jquery
+
+Copyright (c) 2010-2014 Wojciech Zawistowski, Travis Jeffery
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports && typeof exports !== 'undefined') {
+    factory(root, root.jasmine, require('jquery'));
+  } else {
+    factory(root, root.jasmine, root.jQuery);
+  }
+}((function() {return this; })(), function (window, jasmine, $) { "use strict";
+
+  jasmine.spiedEventsKey = function (selector, eventName) {
+    return [$(selector).selector, eventName].toString()
+  }
+
+  jasmine.getFixtures = function () {
+    return jasmine.currentFixtures_ = jasmine.currentFixtures_ || new jasmine.Fixtures()
+  }
+
+  jasmine.getStyleFixtures = function () {
+    return jasmine.currentStyleFixtures_ = jasmine.currentStyleFixtures_ || new jasmine.StyleFixtures()
+  }
+
+  jasmine.Fixtures = function () {
+    this.containerId = 'jasmine-fixtures'
+    this.fixturesCache_ = {}
+    this.fixturesPath = 'spec/javascripts/fixtures'
+  }
+
+  jasmine.Fixtures.prototype.set = function (html) {
+    this.cleanUp()
+    return this.createContainer_(html)
+  }
+
+  jasmine.Fixtures.prototype.appendSet= function (html) {
+    this.addToContainer_(html)
+  }
+
+  jasmine.Fixtures.prototype.preload = function () {
+    this.read.apply(this, arguments)
+  }
+
+  jasmine.Fixtures.prototype.load = function () {
+    this.cleanUp()
+    this.createContainer_(this.read.apply(this, arguments))
+  }
+
+  jasmine.Fixtures.prototype.appendLoad = function () {
+    this.addToContainer_(this.read.apply(this, arguments))
+  }
+
+  jasmine.Fixtures.prototype.read = function () {
+    var htmlChunks = []
+      , fixtureUrls = arguments
+
+    for(var urlCount = fixtureUrls.length, urlIndex = 0; urlIndex < urlCount; urlIndex++) {
+      htmlChunks.push(this.getFixtureHtml_(fixtureUrls[urlIndex]))
+    }
+
+    return htmlChunks.join('')
+  }
+
+  jasmine.Fixtures.prototype.clearCache = function () {
+    this.fixturesCache_ = {}
+  }
+
+  jasmine.Fixtures.prototype.cleanUp = function () {
+    $('#' + this.containerId).remove()
+  }
+
+  jasmine.Fixtures.prototype.sandbox = function (attributes) {
+    var attributesToSet = attributes || {}
+    return $('<div id="sandbox" />').attr(attributesToSet)
+  }
+
+  jasmine.Fixtures.prototype.createContainer_ = function (html) {
+    var container = $('<div>')
+    .attr('id', this.containerId)
+    .html(html)
+
+    $(document.body).append(container)
+    return container
+  }
+
+  jasmine.Fixtures.prototype.addToContainer_ = function (html){
+    var container = $(document.body).find('#'+this.containerId).append(html)
+
+    if (!container.length) {
+      this.createContainer_(html)
+    }
+  }
+
+  jasmine.Fixtures.prototype.getFixtureHtml_ = function (url) {
+    if (typeof this.fixturesCache_[url] === 'undefined') {
+      this.loadFixtureIntoCache_(url)
+    }
+    return this.fixturesCache_[url]
+  }
+
+  jasmine.Fixtures.prototype.loadFixtureIntoCache_ = function (relativeUrl) {
+    var self = this
+      , url = this.makeFixtureUrl_(relativeUrl)
+      , htmlText = ''
+      , request = $.ajax({
+        async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+        cache: false,
+        url: url,
+        dataType: 'html',
+        success: function (data, status, $xhr) {
+          htmlText = $xhr.responseText
+        }
+      }).fail(function ($xhr, status, err) {
+          throw new Error('Fixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+      })
+
+      var scripts = $($.parseHTML(htmlText, true)).find('script[src]') || [];
+
+      scripts.each(function(){
+        $.ajax({
+            async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+            cache: false,
+            dataType: 'script',
+            url: $(this).attr('src'),
+            success: function (data, status, $xhr) {
+                htmlText += '<script>' + $xhr.responseText + '</script>'
+            },
+            error: function ($xhr, status, err) {
+                throw new Error('Script could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+            }
+        });
+      })
+
+      self.fixturesCache_[relativeUrl] = htmlText;
+  }
+
+  jasmine.Fixtures.prototype.makeFixtureUrl_ = function (relativeUrl){
+    return this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl
+  }
+
+  jasmine.Fixtures.prototype.proxyCallTo_ = function (methodName, passedArguments) {
+    return this[methodName].apply(this, passedArguments)
+  }
+
+
+  jasmine.StyleFixtures = function () {
+    this.fixturesCache_ = {}
+    this.fixturesNodes_ = []
+    this.fixturesPath = 'spec/javascripts/fixtures'
+  }
+
+  jasmine.StyleFixtures.prototype.set = function (css) {
+    this.cleanUp()
+    this.createStyle_(css)
+  }
+
+  jasmine.StyleFixtures.prototype.appendSet = function (css) {
+    this.createStyle_(css)
+  }
+
+  jasmine.StyleFixtures.prototype.preload = function () {
+    this.read_.apply(this, arguments)
+  }
+
+  jasmine.StyleFixtures.prototype.load = function () {
+    this.cleanUp()
+    this.createStyle_(this.read_.apply(this, arguments))
+  }
+
+  jasmine.StyleFixtures.prototype.appendLoad = function () {
+    this.createStyle_(this.read_.apply(this, arguments))
+  }
+
+  jasmine.StyleFixtures.prototype.cleanUp = function () {
+    while(this.fixturesNodes_.length) {
+      this.fixturesNodes_.pop().remove()
+    }
+  }
+
+  jasmine.StyleFixtures.prototype.createStyle_ = function (html) {
+    var styleText = $('<div></div>').html(html).text()
+      , style = $('<style>' + styleText + '</style>')
+
+    this.fixturesNodes_.push(style)
+    $('head').append(style)
+  }
+
+  jasmine.StyleFixtures.prototype.clearCache = jasmine.Fixtures.prototype.clearCache
+  jasmine.StyleFixtures.prototype.read_ = jasmine.Fixtures.prototype.read
+  jasmine.StyleFixtures.prototype.getFixtureHtml_ = jasmine.Fixtures.prototype.getFixtureHtml_
+  jasmine.StyleFixtures.prototype.loadFixtureIntoCache_ = jasmine.Fixtures.prototype.loadFixtureIntoCache_
+  jasmine.StyleFixtures.prototype.makeFixtureUrl_ = jasmine.Fixtures.prototype.makeFixtureUrl_
+  jasmine.StyleFixtures.prototype.proxyCallTo_ = jasmine.Fixtures.prototype.proxyCallTo_
+
+  jasmine.getJSONFixtures = function () {
+    return jasmine.currentJSONFixtures_ = jasmine.currentJSONFixtures_ || new jasmine.JSONFixtures()
+  }
+
+  jasmine.JSONFixtures = function () {
+    this.fixturesCache_ = {}
+    this.fixturesPath = 'spec/javascripts/fixtures/json'
+  }
+
+  jasmine.JSONFixtures.prototype.load = function () {
+    this.read.apply(this, arguments)
+    return this.fixturesCache_
+  }
+
+  jasmine.JSONFixtures.prototype.read = function () {
+    var fixtureUrls = arguments
+
+    for(var urlCount = fixtureUrls.length, urlIndex = 0; urlIndex < urlCount; urlIndex++) {
+      this.getFixtureData_(fixtureUrls[urlIndex])
+    }
+
+    return this.fixturesCache_
+  }
+
+  jasmine.JSONFixtures.prototype.clearCache = function () {
+    this.fixturesCache_ = {}
+  }
+
+  jasmine.JSONFixtures.prototype.getFixtureData_ = function (url) {
+    if (!this.fixturesCache_[url]) this.loadFixtureIntoCache_(url)
+    return this.fixturesCache_[url]
+  }
+
+  jasmine.JSONFixtures.prototype.loadFixtureIntoCache_ = function (relativeUrl) {
+    var self = this
+      , url = this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl
+
+    $.ajax({
+      async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+      cache: false,
+      dataType: 'json',
+      url: url,
+      success: function (data) {
+        self.fixturesCache_[relativeUrl] = data
+      },
+      error: function ($xhr, status, err) {
+        throw new Error('JSONFixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+      }
+    })
+  }
+
+  jasmine.JSONFixtures.prototype.proxyCallTo_ = function (methodName, passedArguments) {
+    return this[methodName].apply(this, passedArguments)
+  }
+
+  jasmine.jQuery = function () {}
+
+  jasmine.jQuery.browserTagCaseIndependentHtml = function (html) {
+    return $('<div/>').append(html).html()
+  }
+
+  jasmine.jQuery.elementToString = function (element) {
+    return $(element).map(function () { return this.outerHTML; }).toArray().join(', ')
+  }
+
+  var data = {
+      spiedEvents: {}
+    , handlers:    []
+  }
+
+  jasmine.jQuery.events = {
+    spyOn: function (selector, eventName) {
+      var handler = function (e) {
+        var calls = (typeof data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] !== 'undefined') ? data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0
+        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = {
+          args: jasmine.util.argsToArray(arguments),
+          calls: ++calls
+        }
+      }
+
+      $(selector).on(eventName, handler)
+      data.handlers.push(handler)
+
+      return {
+        selector: selector,
+        eventName: eventName,
+        handler: handler,
+        reset: function (){
+          delete data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        },
+        calls: {
+          count: function () {
+              return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
+                data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0;
+          },
+          any: function () {
+              return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
+                !!data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : false;
+          }
+        }
+      }
+    },
+
+    args: function (selector, eventName) {
+      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args
+
+      if (!actualArgs) {
+        throw "There is no spy for " + eventName + " on " + selector.toString() + ". Make sure to create a spy using spyOnEvent."
+      }
+
+      return actualArgs
+    },
+
+    wasTriggered: function (selector, eventName) {
+      return !!(data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)])
+    },
+
+    wasTriggeredWith: function (selector, eventName, expectedArgs, util, customEqualityTesters) {
+      var actualArgs = jasmine.jQuery.events.args(selector, eventName).slice(1)
+
+      if (Object.prototype.toString.call(expectedArgs) !== '[object Array]')
+        actualArgs = actualArgs[0]
+
+      return util.equals(actualArgs, expectedArgs, customEqualityTesters)
+    },
+
+    wasPrevented: function (selector, eventName) {
+      var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
+        , e = args ? args[0] : undefined
+
+      return e && e.isDefaultPrevented()
+    },
+
+    wasStopped: function (selector, eventName) {
+      var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
+        , e = args ? args[0] : undefined
+
+      return e && e.isPropagationStopped()
+    },
+
+    cleanUp: function () {
+      data.spiedEvents = {}
+      data.handlers    = []
+    }
+  }
+
+  var hasProperty = function (actualValue, expectedValue) {
+    if (expectedValue === undefined)
+      return actualValue !== undefined
+
+    return actualValue === expectedValue
+  }
+
+  beforeEach(function () {
+    jasmine.addMatchers({
+      toHaveClass: function () {
+        return {
+          compare: function (actual, className) {
+            return { pass: $(actual).hasClass(className) }
+          }
+        }
+      },
+
+      toHaveCss: function () {
+        return {
+          compare: function (actual, css) {
+            var stripCharsRegex = /[\s;\"\']/g
+            for (var prop in css) {
+              var value = css[prop]
+              // see issue #147 on gh
+              ;if ((value === 'auto') && ($(actual).get(0).style[prop] === 'auto')) continue
+              var actualStripped = $(actual).css(prop).replace(stripCharsRegex, '')
+              var valueStripped = value.replace(stripCharsRegex, '')
+              if (actualStripped !== valueStripped) return { pass: false }
+            }
+            return { pass: true }
+          }
+        }
+      },
+
+      toBeVisible: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':visible') }
+          }
+        }
+      },
+
+      toBeHidden: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':hidden') }
+          }
+        }
+      },
+
+      toBeSelected: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':selected') }
+          }
+        }
+      },
+
+      toBeChecked: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':checked') }
+          }
+        }
+      },
+
+      toBeEmpty: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':empty') }
+          }
+        }
+      },
+
+      toBeInDOM: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $.contains(document.documentElement, $(actual)[0]) }
+          }
+        }
+      },
+
+      toExist: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).length }
+          }
+        }
+      },
+
+      toHaveLength: function () {
+        return {
+          compare: function (actual, length) {
+            return { pass: $(actual).length === length }
+          }
+        }
+      },
+
+      toHaveAttr: function () {
+        return {
+          compare: function (actual, attributeName, expectedAttributeValue) {
+            return { pass: hasProperty($(actual).attr(attributeName), expectedAttributeValue) }
+          }
+        }
+      },
+
+      toHaveProp: function () {
+        return {
+          compare: function (actual, propertyName, expectedPropertyValue) {
+            return { pass: hasProperty($(actual).prop(propertyName), expectedPropertyValue) }
+          }
+        }
+      },
+
+      toHaveId: function () {
+        return {
+          compare: function (actual, id) {
+            return { pass: $(actual).attr('id') == id }
+          }
+        }
+      },
+
+      toHaveHtml: function () {
+        return {
+          compare: function (actual, html) {
+            return { pass: $(actual).html() == jasmine.jQuery.browserTagCaseIndependentHtml(html) }
+          }
+        }
+      },
+
+      toContainHtml: function () {
+        return {
+          compare: function (actual, html) {
+            var actualHtml = $(actual).html()
+              , expectedHtml = jasmine.jQuery.browserTagCaseIndependentHtml(html)
+
+            return { pass: (actualHtml.indexOf(expectedHtml) >= 0) }
+          }
+        }
+      },
+
+      toHaveText: function () {
+        return {
+          compare: function (actual, text) {
+            var actualText = $(actual).text()
+            var trimmedText = $.trim(actualText)
+
+            if (text && $.isFunction(text.test)) {
+              return { pass: text.test(actualText) || text.test(trimmedText) }
+            } else {
+              return { pass: (actualText == text || trimmedText == text) }
+            }
+          }
+        }
+      },
+
+      toContainText: function () {
+        return {
+          compare: function (actual, text) {
+            var trimmedText = $.trim($(actual).text())
+
+            if (text && $.isFunction(text.test)) {
+              return { pass: text.test(trimmedText) }
+            } else {
+              return { pass: trimmedText.indexOf(text) != -1 }
+            }
+          }
+        }
+      },
+
+      toHaveValue: function () {
+        return {
+          compare: function (actual, value) {
+            return { pass: $(actual).val() === value }
+          }
+        }
+      },
+
+      toHaveData: function () {
+        return {
+          compare: function (actual, key, expectedValue) {
+            return { pass: hasProperty($(actual).data(key), expectedValue) }
+          }
+        }
+      },
+
+      toContainElement: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).find(selector).length }
+          }
+        }
+      },
+
+      toBeMatchedBy: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).filter(selector).length }
+          }
+        }
+      },
+
+      toBeDisabled: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).is(':disabled') }
+          }
+        }
+      },
+
+      toBeFocused: function (selector) {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual)[0] === $(actual)[0].ownerDocument.activeElement }
+          }
+        }
+      },
+
+      toHandle: function () {
+        return {
+          compare: function (actual, event) {
+            if ( !actual || actual.length === 0 ) return { pass: false };
+            var events = $._data($(actual).get(0), "events")
+
+            if (!events || !event || typeof event !== "string") {
+              return { pass: false }
+            }
+
+            var namespaces = event.split(".")
+              , eventType = namespaces.shift()
+              , sortedNamespaces = namespaces.slice(0).sort()
+              , namespaceRegExp = new RegExp("(^|\\.)" + sortedNamespaces.join("\\.(?:.*\\.)?") + "(\\.|$)")
+
+            if (events[eventType] && namespaces.length) {
+              for (var i = 0; i < events[eventType].length; i++) {
+                var namespace = events[eventType][i].namespace
+
+                if (namespaceRegExp.test(namespace))
+                  return { pass: true }
+              }
+            } else {
+              return { pass: (events[eventType] && events[eventType].length > 0) }
+            }
+
+            return { pass: false }
+          }
+        }
+      },
+
+      toHandleWith: function () {
+        return {
+          compare: function (actual, eventName, eventHandler) {
+            if ( !actual || actual.length === 0 ) return { pass: false };
+            var normalizedEventName = eventName.split('.')[0]
+              , stack = $._data($(actual).get(0), "events")[normalizedEventName]
+
+            for (var i = 0; i < stack.length; i++) {
+              if (stack[i].handler == eventHandler) return { pass: true }
+            }
+
+            return { pass: false }
+          }
+        }
+      },
+
+      toHaveBeenTriggeredOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.jQuery.events.wasTriggered(selector, actual) }
+
+            result.message = result.pass ?
+              "Expected event " + $(actual) + " not to have been triggered on " + selector :
+              "Expected event " + $(actual) + " to have been triggered on " + selector
+
+            return result;
+          }
+        }
+      },
+
+      toHaveBeenTriggered: function (){
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+              , selector = actual.selector
+              , result = { pass: jasmine.jQuery.events.wasTriggered(selector, eventName) }
+
+            result.message = result.pass ?
+            "Expected event " + eventName + " not to have been triggered on " + selector :
+              "Expected event " + eventName + " to have been triggered on " + selector
+
+            return result
+          }
+        }
+      },
+
+      toHaveBeenTriggeredOnAndWith: function (j$, customEqualityTesters) {
+        return {
+          compare: function (actual, selector, expectedArgs) {
+            var wasTriggered = jasmine.jQuery.events.wasTriggered(selector, actual)
+              , result = { pass: wasTriggered && jasmine.jQuery.events.wasTriggeredWith(selector, actual, expectedArgs, j$, customEqualityTesters) }
+
+              if (wasTriggered) {
+                var actualArgs = jasmine.jQuery.events.args(selector, actual, expectedArgs)[1]
+                result.message = result.pass ?
+                  "Expected event " + actual + " not to have been triggered with " + jasmine.pp(expectedArgs) + " but it was triggered with " + jasmine.pp(actualArgs) :
+                  "Expected event " + actual + " to have been triggered with " + jasmine.pp(expectedArgs) + "  but it was triggered with " + jasmine.pp(actualArgs)
+
+              } else {
+                // todo check on this
+                result.message = result.pass ?
+                  "Expected event " + actual + " not to have been triggered on " + selector :
+                  "Expected event " + actual + " to have been triggered on " + selector
+              }
+
+              return result
+          }
+        }
+      },
+
+      toHaveBeenPreventedOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.jQuery.events.wasPrevented(selector, actual) }
+
+            result.message = result.pass ?
+              "Expected event " + actual + " not to have been prevented on " + selector :
+              "Expected event " + actual + " to have been prevented on " + selector
+
+            return result
+          }
+        }
+      },
+
+      toHaveBeenPrevented: function () {
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+              , selector = actual.selector
+              , result = { pass: jasmine.jQuery.events.wasPrevented(selector, eventName) }
+
+            result.message = result.pass ?
+              "Expected event " + eventName + " not to have been prevented on " + selector :
+              "Expected event " + eventName + " to have been prevented on " + selector
+
+            return result
+          }
+        }
+      },
+
+      toHaveBeenStoppedOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.jQuery.events.wasStopped(selector, actual) }
+
+            result.message = result.pass ?
+              "Expected event " + actual + " not to have been stopped on " + selector :
+              "Expected event " + actual + " to have been stopped on " + selector
+
+            return result;
+          }
+        }
+      },
+
+      toHaveBeenStopped: function () {
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+              , selector = actual.selector
+              , result = { pass: jasmine.jQuery.events.wasStopped(selector, eventName) }
+
+            result.message = result.pass ?
+              "Expected event " + eventName + " not to have been stopped on " + selector :
+              "Expected event " + eventName + " to have been stopped on " + selector
+
+            return result
+          }
+        }
+      }
+    })
+
+    jasmine.getEnv().addCustomEqualityTester(function(a, b) {
+     if (a && b) {
+       if (a instanceof $ || jasmine.isDomNode(a)) {
+         var $a = $(a)
+
+         if (b instanceof $)
+           return $a.length == b.length && $a.is(b)
+
+         return $a.is(b);
+       }
+
+       if (b instanceof $ || jasmine.isDomNode(b)) {
+         var $b = $(b)
+
+         if (a instanceof $)
+           return a.length == $b.length && $b.is(a)
+
+         return $b.is(a);
+       }
+     }
+    })
+
+    jasmine.getEnv().addCustomEqualityTester(function (a, b) {
+     if (a instanceof $ && b instanceof $ && a.size() == b.size())
+        return a.is(b)
+    })
+  })
+
+  afterEach(function () {
+    jasmine.getFixtures().cleanUp()
+    jasmine.getStyleFixtures().cleanUp()
+    jasmine.jQuery.events.cleanUp()
+  })
+
+  window.readFixtures = function () {
+    return jasmine.getFixtures().proxyCallTo_('read', arguments)
+  }
+
+  window.preloadFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('preload', arguments)
+  }
+
+  window.loadFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('load', arguments)
+  }
+
+  window.appendLoadFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('appendLoad', arguments)
+  }
+
+  window.setFixtures = function (html) {
+    return jasmine.getFixtures().proxyCallTo_('set', arguments)
+  }
+
+  window.appendSetFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('appendSet', arguments)
+  }
+
+  window.sandbox = function (attributes) {
+    return jasmine.getFixtures().sandbox(attributes)
+  }
+
+  window.spyOnEvent = function (selector, eventName) {
+    return jasmine.jQuery.events.spyOn(selector, eventName)
+  }
+
+  window.preloadStyleFixtures = function () {
+    jasmine.getStyleFixtures().proxyCallTo_('preload', arguments)
+  }
+
+  window.loadStyleFixtures = function () {
+    jasmine.getStyleFixtures().proxyCallTo_('load', arguments)
+  }
+
+  window.appendLoadStyleFixtures = function () {
+    jasmine.getStyleFixtures().proxyCallTo_('appendLoad', arguments)
+  }
+
+  window.setStyleFixtures = function (html) {
+    jasmine.getStyleFixtures().proxyCallTo_('set', arguments)
+  }
+
+  window.appendSetStyleFixtures = function (html) {
+    jasmine.getStyleFixtures().proxyCallTo_('appendSet', arguments)
+  }
+
+  window.loadJSONFixtures = function () {
+    return jasmine.getJSONFixtures().proxyCallTo_('load', arguments)
+  }
+
+  window.getJSONFixture = function (url) {
+    return jasmine.getJSONFixtures().proxyCallTo_('read', arguments)[url]
+  }
+}));

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,145 @@
+# src_files
+#
+# Return an array of filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# src_files:
+#   - lib/source1.js
+#   - lib/source2.js
+#   - 'dist/**/*.js'
+#
+src_files:
+  - assets/application.js
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - 'stylesheets/*.css'
+#
+stylesheets:
+  - assets/application.css
+
+# helpers
+#
+# Return an array of filepaths relative to spec_dir to include before jasmine specs.
+# Default: ["helpers/**/*.js"]
+#
+# EXAMPLE:
+#
+# helpers:
+#   - 'helpers/**/*.js'
+#
+helpers:
+  - 'helpers/**/*.js'
+
+# spec_files
+#
+# Return an array of filepaths relative to spec_dir to include.
+# Default: ["**/*[sS]pec.js"]
+#
+# EXAMPLE:
+#
+# spec_files:
+#   - '**/*[sS]pec.js'
+#
+spec_files:
+  - '**/*[sS]pec.js'
+
+# src_dir
+#
+# Source directory path. Your src_files must be returned relative to this path. Will use root if left blank.
+# Default: project root
+#
+# EXAMPLE:
+#
+# src_dir: public
+#
+src_dir:
+
+# spec_dir
+#
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
+#
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir:
+
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+spec_helper: spec/javascripts/support/jasmine_helper.rb
+
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
+
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+
+# phantom_cli_options
+#
+# Extra options to be passed to the phantomjs cli,
+# e.g. to enable localStorage in PhantomJs 2.5
+#
+# EXAMPLE
+#
+# phantom_cli_options:
+#   local-storage-quota: 5000
+
+# random
+#
+# Run specs in semi-random order.
+# Default: false
+#
+# EXAMPLE:
+#
+# random: true
+#
+random:
+

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,0 +1,14 @@
+# Use this file to set/override Jasmine configuration options
+# You can remove it if you don't need it.
+# This file is loaded *after* jasmine.yml is interpreted.
+#
+# Example: using a different boot file.
+# Jasmine.configure do |config|
+#    config.boot_dir = '/absolute/path/to/boot_dir'
+#    config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
+# end
+#
+# Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
+Jasmine.configure do |config|
+  config.prevent_phantom_js_auto_install = true if ENV['TRAVIS']
+end

--- a/spec/javascripts/validation_service_spec.js
+++ b/spec/javascripts/validation_service_spec.js
@@ -1,0 +1,22 @@
+describe("ValidationService", function() {
+  var VisibilityComponent = require('hyrax/save_work/validation_service');
+  var form = null;
+  var target = null;
+
+  beforeEach(function() {
+    var fixture = setFixtures('<form id="edit_image">' +
+        '<select><option></option></select>' +
+        '<aside id="form-progress"><ul><li id="required-metadata"><li id="required-files"><li id="required-agreement"></ul>' +
+        '<input type="checkbox" name="agreement" id="agreement" value="1" required="required" checked="checked" />' +
+        '<input type="submit"></aside></form>');
+    form = fixture.find('#edit_image');
+    target = new VisibilityComponent(form, false);
+  });
+
+  it("checks validation service before submit", function() {
+    spyOn(target, 'checkValidationService');
+    form.trigger('submit');
+    expect(target.checkValidationService).toHaveBeenCalled();
+  })
+
+});


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/486

* works around the problem with resubmitting a failed form validation by using the `Donut::ValidationService` to validate via JavaScript before the form is submitted.
  * Adds `app/controllers/validation_controller.rb` to handle validation requests
  * Adds `app/assets/javascripts/hyrax/save_work/validation_service.es6` to handle the JavaScript validation
  * overrides Hyrax `app/assets/javascripts/hyrax/save_work/save_work_control.es6` to use the validation service on submit
* Adds Jasmine and a JavaScript test + updates readme
* Makes accession_number read only on edit form
* Removes the duplicate *NUL Subject* field from image display
