### PR TITLE
Adds technical metadata to facets

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -91,6 +91,17 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('sculptor_label', :facetable), label: 'Sculptor', limit: 5
     config.add_facet_field solr_name('sponsor_label', :facetable), label: 'Sponsor', limit: 5
 
+    # exif metadata
+    config.add_facet_field solr_name('height', :facetable), label: 'Height', limit: 5
+    config.add_facet_field solr_name('width', :facetable), label: 'Width', limit: 5
+    config.add_facet_field solr_name('bits_per_sample', :facetable), label: 'Bits Per Sample', limit: 5
+    config.add_facet_field solr_name('compression', :facetable), label: 'Compression', limit: 5
+    config.add_facet_field solr_name('photometric_interpretation', :facetable), label: 'Photometric Interpretation', limit: 5
+    config.add_facet_field solr_name('make', :facetable), label: 'Make', limit: 5
+    config.add_facet_field solr_name('x_resolution', :facetable), label: 'X Resolution', limit: 5
+    config.add_facet_field solr_name('y_resolution', :facetable), label: 'Y Resolution', limit: 5
+    config.add_facet_field solr_name('icc_profile_description', :facetable), label: 'Profile Description', limit: 5
+
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile
     config.add_facet_field solr_name('generic_type', :facetable), if: false

--- a/app/indexers/image_indexer.rb
+++ b/app/indexers/image_indexer.rb
@@ -17,7 +17,22 @@ class ImageIndexer < Hyrax::WorkIndexer
         file_set = ::FileSet.find(file_set_id)
         next if file_set.original_file.nil?
         (solr_doc['file_set_iiif_urls_ssim'] ||= []) << IiifDerivativeService.resolve(file_set.original_file.id).to_s
+        index_technical_metadata(solr_doc, file_set)
       end
     end
   end
+
+  # rubocop:disable Metrics/AbcSize
+  def index_technical_metadata(solr_doc, file_set)
+    (solr_doc['width_sim'] ||= []) << file_set.characterization_proxy.width.first
+    (solr_doc['height_sim'] ||= []) << file_set.characterization_proxy.height.first
+    (solr_doc['bits_per_sample_sim'] ||= []) << file_set.characterization_proxy.bits_per_sample.first
+    (solr_doc['compression_sim'] ||= []) << file_set.characterization_proxy.compression.first
+    (solr_doc['photometric_interpretation_sim'] ||= []) << file_set.characterization_proxy.photometric_interpretation.first
+    (solr_doc['make_sim'] ||= []) << file_set.characterization_proxy.make.first
+    (solr_doc['x_resolution_sim'] ||= []) << file_set.characterization_proxy.x_resolution.first
+    (solr_doc['y_resolution_sim'] ||= []) << file_set.characterization_proxy.y_resolution.first
+    (solr_doc['icc_profile_description_sim'] ||= []) << file_set.characterization_proxy.icc_profile_description.first
+  end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/presenters/hyrax/characterization_behavior.rb
+++ b/app/presenters/hyrax/characterization_behavior.rb
@@ -5,7 +5,7 @@ module Hyrax
     class_methods do
       def characterization_terms
         [
-          :byte_order, :compression, :height, :width, :height, :color_space,
+          :byte_order, :compression, :height, :width, :color_space,
           :profile_name, :profile_version, :orientation, :color_map, :image_producer,
           :capture_device, :scanning_software, :gps_timestamp, :latitude, :longitude,
           :file_format, :file_title, :page_count, :duration, :sample_rate,

--- a/config/initializers/delegate_metadata_to_file_set_presenter.rb
+++ b/config/initializers/delegate_metadata_to_file_set_presenter.rb
@@ -2,7 +2,7 @@ Hyrax::FileSetPresenter.class_eval do
   delegate :width, :height, :compression,
            :photometric_interpretation, :samples_per_pixel,
            :x_resolution, :y_resolution, :resolution_unit, :date_time,
-           :bits_per_sample, :make, :model, :strip_offsets,
+           :bits_per_sample, :make, :strip_offsets,
            :rows_per_strip, :strip_byte_counts, :software,
            :extra_samples, :icc_profile_description,
            to: :solr_document

--- a/spec/indexers/image_indexer_spec.rb
+++ b/spec/indexers/image_indexer_spec.rb
@@ -14,7 +14,12 @@ describe ImageIndexer do
 
     context 'with an image' do
       let(:image) { FactoryBot.build(:image, date_created: ['1987~', 'uuuu']) }
-      let(:file_set) { FactoryBot.create(:file_set).tap { |fs| fs.original_file = file } }
+      let(:file_set) do
+        FactoryBot.create(:file_set).tap do |fs|
+          fs.original_file = file
+          fs.characterization_proxy.x_resolution = [600]
+        end
+      end
       let(:iiif_url) { 'http://thisistheiiifurl' }
 
       let(:file) do
@@ -31,6 +36,10 @@ describe ImageIndexer do
 
       it 'indexes the iiif url for the filesets' do
         expect(solr_doc['file_set_iiif_urls_ssim']).to match_array(iiif_url)
+      end
+
+      it 'indexes the exif metadata for the filesets' do
+        expect(solr_doc['x_resolution_sim']).to match_array([600])
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/459

* indexes the technical metadata for `FileSet.characterization_proxy` at the (parent) Image level so it can be exposed in facets, and searched.

Co-authored-by: Brendan Quinn <brendan-quinn@northwestern.edu>
