### PR TITLE
temporarily hides collection branding form

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form_branding.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_branding.html.erb
@@ -1,0 +1,5 @@
+<div class="set-access-controls">
+  <h3><%= t('.branding.label') %></h3>
+  <p>We are currently not using Hyrax's collection branding features.</p>
+  <p>Alternatively, please go to the <a href='#description'>Description tab</a> to choose a thumbnail to represent the collection</p>
+</div> <!-- end set-access-controls -->


### PR DESCRIPTION
* Temporarily disable collection branding form so as not to cause confusion. 
* Provide message linking to 'Discovery' tab with instructions to choose representative thumbnail for the collection instead.


Co-authored-by: Brendan Quinn <brendan-quinn@northwestern.edu>