### PR TITLE
Move ClamAV gem to production group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,8 +102,11 @@ group :aws do
   gem 'aws-sdk', '~> 3'
   gem 'aws-sdk-rails'
   gem 'carrierwave-aws'
-  gem 'clamav'
   gem 'cloudfront-signer'
   gem 'redis-rails'
   gem 'zk'
+end
+
+group :production do
+  gem 'clamav'
 end


### PR DESCRIPTION
This prevents devs from having to install ClamAV locally in order to get the environment to load.