### PR TITLE
Override how Hyrax creates system users and create default configuration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,10 @@ class User < ApplicationRecord
     email
   end
 
+  def self.find_or_create_system_user(user_key)
+    find_or_create_by(Hydra.config.user_key_field => user_key)
+  end
+
   def self.from_omniauth(auth)
     username = auth.uid
     email = auth.info.email

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -140,10 +140,10 @@ Hyrax.config do |config|
   # config.display_share_button_when_not_logged_in = true
 
   # The user who runs batch jobs. Update this if you aren't using emails
-  # config.batch_user_key = 'batchuser@example.com'
+  config.batch_user_key = Settings.system_user
 
   # The user who runs fixity check jobs. Update this if you aren't using emails
-  # config.audit_user_key = 'audituser@example.com'
+  config.audit_user_key = Settings.system_user
   #
   # The banner image. Should be 5000px wide by 1000px tall
   # config.banner_image = 'https://cloud.githubusercontent.com/assets/92044/18370978/88ecac20-75f6-11e6-8399-6536640ef695.jpg'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,3 +26,4 @@ aws:
   buckets: {}
   queues: {}
 ffmpeg: {}
+system_user: 'repository@northwestern.edu'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe User do
+  it '.batch_user' do
+    expect(described_class.batch_user.email).to eq(Settings.system_user)
+  end
+
+  it '.audit_user' do
+    expect(described_class.audit_user.email).to eq(Settings.system_user)
+  end
+end


### PR DESCRIPTION
Fixes an issue where Hyrax will raise an exception attempting to create a system user in a password-less configuration.