### PR TITLE
alias capture_device to model, make it visible in the ui

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -98,6 +98,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('compression', :facetable), label: 'Compression', limit: 5
     config.add_facet_field solr_name('photometric_interpretation', :facetable), label: 'Photometric Interpretation', limit: 5
     config.add_facet_field solr_name('make', :facetable), label: 'Make', limit: 5
+    config.add_facet_field solr_name('model', :facetable), label: 'Model', limit: 5
     config.add_facet_field solr_name('x_resolution', :facetable), label: 'X Resolution', limit: 5
     config.add_facet_field solr_name('y_resolution', :facetable), label: 'Y Resolution', limit: 5
     config.add_facet_field solr_name('icc_profile_description', :facetable), label: 'Profile Description', limit: 5

--- a/app/indexers/image_indexer.rb
+++ b/app/indexers/image_indexer.rb
@@ -30,6 +30,7 @@ class ImageIndexer < Hyrax::WorkIndexer
     (solr_doc['compression_sim'] ||= []) << file_set.characterization_proxy.compression.first
     (solr_doc['photometric_interpretation_sim'] ||= []) << file_set.characterization_proxy.photometric_interpretation.first
     (solr_doc['make_sim'] ||= []) << file_set.characterization_proxy.make.first
+    (solr_doc['model_sim'] ||= []) << file_set.characterization_proxy.model.first
     (solr_doc['x_resolution_sim'] ||= []) << file_set.characterization_proxy.x_resolution.first
     (solr_doc['y_resolution_sim'] ||= []) << file_set.characterization_proxy.y_resolution.first
     (solr_doc['icc_profile_description_sim'] ||= []) << file_set.characterization_proxy.icc_profile_description.first

--- a/app/models/concerns/hyrax/file_set/characterization.rb
+++ b/app/models/concerns/hyrax/file_set/characterization.rb
@@ -22,7 +22,7 @@ module Hyrax
           :page_count, :file_title, :last_modified, :original_checksum,
           :duration, :sample_rate, :compression, :photometric_interpretation,
           :samples_per_pixel, :x_resolution, :y_resolution, :resolution_unit,
-          :date_time, :bits_per_sample, :make, :strip_offsets,
+          :date_time, :bits_per_sample, :make, :model, :strip_offsets,
           :rows_per_strip, :strip_byte_counts, :icc_profile_description,
           :donut_exif_version, :exif_all_data
         ]

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -329,6 +329,10 @@ class SolrDocument
     fetch(Solrizer.solr_name('make', :stored_searchable), [])
   end
 
+  def model
+    fetch(Solrizer.solr_name('model', :stored_searchable), [])
+  end
+
   def strip_offsets
     fetch(Solrizer.solr_name('strip_offsets', :stored_searchable), [])
   end

--- a/app/presenters/hyrax/characterization_behavior.rb
+++ b/app/presenters/hyrax/characterization_behavior.rb
@@ -7,12 +7,12 @@ module Hyrax
         [
           :byte_order, :compression, :height, :width, :color_space,
           :profile_name, :profile_version, :orientation, :color_map, :image_producer,
-          :capture_device, :scanning_software, :gps_timestamp, :latitude, :longitude,
+          :scanning_software, :gps_timestamp, :latitude, :longitude,
           :file_format, :file_title, :page_count, :duration, :sample_rate,
           :format_label, :file_size, :filename, :well_formed, :last_modified,
           :original_checksum, :mime_type, :photometric_interpretation,
           :samples_per_pixel, :x_resolution, :y_resolution, :resolution_unit,
-          :date_time, :bits_per_sample, :make, :strip_offsets,
+          :date_time, :bits_per_sample, :make, :model, :strip_offsets,
           :rows_per_strip, :strip_byte_counts, :icc_profile_description,
           :donut_exif_version
         ]

--- a/app/services/donut/characterization_service.rb
+++ b/app/services/donut/characterization_service.rb
@@ -9,6 +9,7 @@ module Donut
       date_time:                  [:'xmp-xmp', 'CreateDate'],
       bits_per_sample:            [:ifd0, 'BitsPerSample'],
       make:                       [:ifd0, 'Make'],
+      model:                      [:ifd0, 'Model'],
       strip_offsets:              [:ifd0, 'StripOffsets'],
       rows_per_strip:             [:ifd0, 'RowsPerStrip'],
       strip_byte_counts:          [:ifd0, 'StripByteCounts'],

--- a/config/initializers/capture_device_alias_to_model.rb
+++ b/config/initializers/capture_device_alias_to_model.rb
@@ -1,0 +1,3 @@
+Hydra::PCDM::File.class_eval do
+  alias_attribute :model, :capture_device
+end

--- a/config/initializers/delegate_metadata_to_file_set_presenter.rb
+++ b/config/initializers/delegate_metadata_to_file_set_presenter.rb
@@ -2,7 +2,7 @@ Hyrax::FileSetPresenter.class_eval do
   delegate :width, :height, :compression,
            :photometric_interpretation, :samples_per_pixel,
            :x_resolution, :y_resolution, :resolution_unit, :date_time,
-           :bits_per_sample, :make, :strip_offsets,
+           :bits_per_sample, :make, :model, :strip_offsets,
            :rows_per_strip, :strip_byte_counts, :software,
            :extra_samples, :icc_profile_description,
            to: :solr_document

--- a/config/initializers/extend_file_set_indexer.rb
+++ b/config/initializers/extend_file_set_indexer.rb
@@ -34,6 +34,7 @@ Hyrax::FileSetIndexer.class_eval do
       solr_doc['date_time_tesim'] = object.date_time
       solr_doc['bits_per_sample_tesim'] = object.bits_per_sample
       solr_doc['make_tesim'] = object.make
+      solr_doc['model_tesim'] = object.model
       solr_doc['strip_offsets_tesim'] = object.strip_offsets
       solr_doc['rows_per_strip_tesim'] = object.rows_per_strip
       solr_doc['strip_byte_counts_tesim'] = object.strip_byte_counts

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe SolrDocument do
       date_time_tesim: ['2018-01-01'],
       bits_per_sample_tesim: ['1'],
       make_tesim: ['nec scanner'],
+      model_tesim: ['SupraScanQuartzA1 [SN: 331001] - CamQuartzHD [SN: 331001]'],
       strip_offsets_tesim: ['1'],
       rows_per_strip_tesim: ['1'],
       strip_byte_counts_tesim: ['1'],
@@ -129,6 +130,12 @@ RSpec.describe SolrDocument do
   describe '#make' do
     it 'returns make' do
       expect(solr_doc.make).to eq ['nec scanner']
+    end
+  end
+
+  describe '#model' do
+    it 'returns model' do
+      expect(solr_doc.model).to eq ['SupraScanQuartzA1 [SN: 331001] - CamQuartzHD [SN: 331001]']
     end
   end
 

--- a/spec/services/donut/characterization_service_spec.rb
+++ b/spec/services/donut/characterization_service_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Donut::CharacterizationService do
     expect(file.date_time).to eq ['2014:07:16 10:26:11']
     expect(file.bits_per_sample).to eq ['8 8 8']
     expect(file.make).to eq ['i2S, Corp.']
+    expect(file.model).to eq ['SupraScanQuartzA1 [SN: 331001] - CamQuartzHD [SN: 331001]']
     expect(file.strip_offsets).to eq [34_612]
     expect(file.rows_per_strip).to eq [6212]
     expect(file.strip_byte_counts).to eq [102_125_280]


### PR DESCRIPTION
fixes https://github.com/nulib/next-generation-repository/issues/542 

`capture_device` already exists in hydra works, so instead of creating another one, i've aliased `model` to `capture_device` and made `model` visible in the UI