### PR TITLE
disable Hyrax fileset versioning

### DIFF
--- a/app/views/hyrax/file_sets/_versioning.html.erb
+++ b/app/views/hyrax/file_sets/_versioning.html.erb
@@ -1,0 +1,4 @@
+<div id="versioning_display" class="tab-pane">
+  <h2>Versions</h2>
+  <div class="alert alert-warning"><p>We are not currently using the Hyrax versioning feature.</p><p> Alternatively, please delete and re-ingest the file set.</p></div>
+</div> <!-- /row -->


### PR DESCRIPTION
* Per Laura and David, disable versions until bugs are fixed and provide help text suggesting to delete and re-ingest the file instead. 
* overrides `app/views/hyrax/file_sets/_versioning.html.erb` from Hyrax

References https://github.com/nulib/next-generation-repository/issues/476