### PR TITLE
Allow visibility in batch manifest

### DIFF
--- a/app/batch/importer/csv_parser.rb
+++ b/app/batch/importer/csv_parser.rb
@@ -57,7 +57,7 @@ module Importer
       end
 
       def valid_headers
-        Image.attribute_names + %w[id type file] + collection_headers
+        Image.attribute_names + %w[id type file visibility] + collection_headers
       end
 
       def collection_headers
@@ -76,7 +76,7 @@ module Importer
       def extract_field(header, val, processed)
         return if val.blank?
         case header
-        when 'type', 'accession_number', 'id', 'status', 'ark', 'call_number', 'preservation_level'
+        when 'type', 'accession_number', 'id', 'status', 'ark', 'call_number', 'preservation_level', 'visibility'
           # single valued fields
           processed[header.to_sym] = val
         when /^(created|issued|date_copyrighted|date_valid)_(.*)$/

--- a/spec/batch/importer/csv_parser_spec.rb
+++ b/spec/batch/importer/csv_parser_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Importer::CSVParser do
     subject(:parsed_headers) { parser.send(:validate_headers, headers) }
 
     context 'with valid headers' do
-      let(:headers) { %w[id title accession_number date_created rights_statement preservation_level status file type] }
+      let(:headers) { %w[id title accession_number date_created rights_statement preservation_level status file type visibility] }
 
       it 'contains the correct headers' do
         expect(parsed_headers).to eq headers


### PR DESCRIPTION
References https://github.com/nulib/next-generation-repository/issues/567
Fixes https://github.com/nulib/next-generation-repository/issues/584

## Description
Allows users to add the header 'visibility' to the batch spreadsheet with one of these values:
- 'open' for Public
- 'authenticated' for Institution
- 'restricted' for Private

## Changes 
* Add visibility to valid headers in `csv_parser.rb`
* Add visibility to list of single valued fields in `csv_parser.rb`