### PR TITLE
Add resource_type, file iiif urls, and id to image indexer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,8 @@ Metrics/LineLength:
 
 Metrics/MethodLength:
   Max: 14 # default is 10
+  Exclude:
+    - 'app/services/common_indexers/image.rb'
 
 Layout/IndentationConsistency:
   EnforcedStyle: rails

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,6 +10,7 @@
 Metrics/AbcSize:
   Exclude:
     - 'app/jobs/import_url_job.rb'
+    - 'app/services/common_indexers/image.rb'
   Max: 20
 RSpec/MessageSpies:
   Exclude:

--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -42,6 +42,7 @@ module Hyrax
                                    RDF::URI('http://www.w3.org/2003/01/geo/wgs84_pos#long') => :long
                                  })
           results = query.execute(graph)
+          return {} if results.empty?
           lat = results.first[:lat].to_s
           long = results.first[:long].to_s
           { lat: lat, lon: long }

--- a/spec/lib/hyrax/controlled_vocabularies/location_spec.rb
+++ b/spec/lib/hyrax/controlled_vocabularies/location_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Hyrax::ControlledVocabularies::Location do
   let(:resource) {  described_class.new(RDF::URI(uri)) }
-  let(:cache_key) { "fetch:http://sws.geonames.org/5099836" }
+  let(:cache_key) { 'fetch:http://sws.geonames.org/5099836' }
   let(:cache) { instance_double(ActiveSupport::Cache::Store) }
   let(:geo_triple) { file_fixture('5746545.ntz').read }
 


### PR DESCRIPTION
* updates common indexer to include fileset_iiif_urls, represetnative file iiif url (without dimensions), resource type and id. (all needed for front end display)
* Also implement a guard clause to prevent an error running `to_common_index` in case bad data `www.geonames` instead of `sws.geonames` is already stored in an existing record.