### PR TITLE
configure rdf_label to handle geonames

### DIFF
--- a/app/models/controlled_vocabularies/base.rb
+++ b/app/models/controlled_vocabularies/base.rb
@@ -1,5 +1,6 @@
 module ControlledVocabularies
   class Base < ActiveTriples::Resource
+    configure rdf_label: ::RDF::Vocab::GEONAMES.name
     include CachingFetcher
     require 'rdf/rdfxml'
 


### PR DESCRIPTION
Fixes: https://github.com/nulib/next-generation-repository/issues/601

* adds `::RDF::Vocab::GEONAMES.name` to the `rdf_label` configuration so geonames can find labels in Subject Geographical