### PR TITLE
Fixes bug where partial accession match is considered duplicate

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -32,7 +32,7 @@ class Image < ActiveFedora::Base
   end
 
   property :accession_number, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/subjectSchemes/local'), multiple: false do |index|
-    index.as :stored_searchable
+    index.as :symbol
   end
 
   property :ark, predicate: ::RDF::Vocab::DataCite.ark, multiple: false do |index|

--- a/app/services/donut/duplicate_accession_verification_service.rb
+++ b/app/services/donut/duplicate_accession_verification_service.rb
@@ -20,7 +20,7 @@ module Donut
     # return [Array<String>] array of pids
     def duplicate_ids
       return [] if accession_number.nil?
-      Image.where(accession_number_tesim: @accession_number)
+      Image.where(accession_number_ssim: @accession_number)
     end
   end
 end

--- a/spec/models/batch_item_spec.rb
+++ b/spec/models/batch_item_spec.rb
@@ -98,6 +98,25 @@ RSpec.describe BatchItem, :clean, type: :model, admin_set: true do
     end
   end
 
+  context 'partial duplicate of accession number' do
+    let(:accession_number) { '1234' }
+    let(:prior_accession_number) { '1234-5678' }
+
+    let(:attributes) { common_attributes.reject { |k, _v| k == :accession_number }.merge(accession_number: accession_number) }
+    let(:prior_attributes) { common_attributes.reject { |k, _v| k == :accession_number }.merge(accession_number: prior_accession_number) }
+    let(:prior_batch) { Batch.create(submitter: submitter, job_id: job_id.reverse, original_filename: original_filename) }
+    let(:prior_item) { prior_batch.batch_items.create(accession_number: prior_accession_number, attribute_hash: prior_attributes, row_number: 1) }
+
+    before do
+      prior_item.complete!
+      batch_item.run
+    end
+
+    it 'is not skipped' do
+      expect(batch_item.status).to eq('complete')
+    end
+  end
+
   context 'controlled property with invalid value' do
     let(:contributor) { ['Text M. Stringer'] }
     let(:attributes)  { common_attributes }

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SolrDocument do
       title_tesim: ['Test title'],
       alternate_title_tesim: ['Alternate Title 1'],
       abstract_tesim: ['Lemon drops donut gummi bears carrot cake dragée.'],
-      accession_number_tesim: ['Lgf0825'],
+      accession_number_ssim: ['Lgf0825'],
       box_name_tesim: ['A good box name'],
       box_number_tesim: ['42'],
       call_number_tesim: ['W107.8:Am6'],

--- a/spec/services/donut/duplicate_accession_verification_service_spec.rb
+++ b/spec/services/donut/duplicate_accession_verification_service_spec.rb
@@ -9,7 +9,7 @@ describe Donut::DuplicateAccessionVerificationService do
   let(:service)              { described_class.new(accession_number) }
 
   context 'when no duplicate accession numbers exist' do
-    before { allow(Image).to receive(:where).with(accession_number_tesim: accession_number).and_return([]) }
+    before { allow(Image).to receive(:where).with(accession_number_ssim: accession_number).and_return([]) }
     it { is_expected.to be_empty }
   end
 
@@ -17,7 +17,7 @@ describe Donut::DuplicateAccessionVerificationService do
     let(:image) { FactoryBot.create(:image, accession_number: 'nul:999') }
 
     before do
-      allow(Image).to receive(:where).with(accession_number_tesim: accession_number).and_return([image.id])
+      allow(Image).to receive(:where).with(accession_number_ssim: accession_number).and_return([image.id])
     end
     it { is_expected.to contain_exactly(image.id) }
   end
@@ -26,7 +26,7 @@ describe Donut::DuplicateAccessionVerificationService do
     subject { described_class.unique?(accession_number) }
 
     context 'when no duplicate accession numbers exist' do
-      before { allow(Image).to receive(:where).with(accession_number_tesim: accession_number).and_return([]) }
+      before { allow(Image).to receive(:where).with(accession_number_ssim: accession_number).and_return([]) }
       it { is_expected.to be(true) }
     end
   end
@@ -38,7 +38,7 @@ describe Donut::DuplicateAccessionVerificationService do
       let(:image) { FactoryBot.create(:image, accession_number: 'nul:999') }
 
       before do
-        allow(Image).to receive(:where).with(accession_number_tesim: accession_number).and_return([image.id])
+        allow(Image).to receive(:where).with(accession_number_ssim: accession_number).and_return([image.id])
       end
       it { is_expected.to be(true) }
     end


### PR DESCRIPTION
Fixes: https://github.com/nulib/next-generation-repository/issues/630

* index accession number as `_ssim` rather than `_tesim` which was causing the accession number to be tokenized at dashes and find duplicates for a partial match like "inu-wint-26-52" and  "inu-wint-26-52-placeholder" and then skip the batch item.