### PR TITLE
Override label for Description

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,5 +1,6 @@
 <%= presenter.attribute_to_html(:alternate_title) %>
 <%= presenter.attribute_to_html(:accession_number) %>
+<%= presenter.attribute_to_html(:abstract, label: 'Abstract') %>
 <%= presenter.attribute_to_html(:ark, label: 'ARK') %>
 <%= presenter.attribute_to_html(:based_near_label, label: 'Place of Publication') %>
 <%= presenter.attribute_to_html(:bibliographic_citation, label: 'Citation') %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1,4 +1,8 @@
 en:
+  simple_form:
+    labels:
+      defaults:
+        description: Description
   blacklight:
     search:
       fields:


### PR DESCRIPTION
Fixes: https://github.com/nulib/next-generation-repository/issues/636

* Override Hyrax default label for `description` in the new/edit form - change from "Abstract or Summary" to "Description"
* Show NU's `abstract` field to the show view. 