### PR TITLE
Fixes 633, default the application to start blocking all robots, only…

### DIFF
--- a/config/initializers/robots.rb
+++ b/config/initializers/robots.rb
@@ -1,0 +1,6 @@
+# Picks which robot we should use
+robot_file = 'no_robots.txt'
+robot_file = 'prod_robots.txt' if Rails.env == 'production'
+src_path = Pathname.new(Rails.root.to_s + "/public/#{robot_file}")
+target_path = Pathname.new(Rails.root.to_s + '/public/robots.txt')
+FileUtils.cp src_path, target_path

--- a/public/no_robots.txt
+++ b/public/no_robots.txt
@@ -1,0 +1,3 @@
+# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /

--- a/public/prod_robots.txt
+++ b/public/prod_robots.txt
@@ -1,0 +1,1 @@
+# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file


### PR DESCRIPTION
… in the production environment use the prod_robots.txt file that allows robots

fixes https://github.com/nulib/next-generation-repository/issues/633