### PR TITLE
Tweak the configs and rake tasks to work well with the docker-stack gem *and* standalone devstack.

### DIFF
--- a/.docker-stack/nextgen-development/docker-compose.yml
+++ b/.docker-stack/nextgen-development/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     - 9985:9983
     volumes:
     - solr:/opt/solr/server/solr/mycores
+    command: solr -f -cloud
     healthcheck:
       test:
       - CMD

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,3 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
-
-require 'solr_wrapper/rake_task' unless Rails.env.production?
-require 'fcrepo_wrapper/rake_task' unless Rails.env.production?

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -16,13 +16,9 @@ if Rails.env.development? || Rails.env.test?
 
       desc 'Spin up test stack and run specs'
       task :spec do
-        Rails.env = 'test'
+        Rake::Task['donut:load_test_config'].invoke
         Docker::Stack::Controller.new(cleanup: true).with_containers do
-          Rake::Task['db:setup'].invoke
-          Rake::Task['zookeeper:upload'].invoke
-          Rake::Task['zookeeper:create'].invoke
-          Rake::Task['elasticsearch:init'].invoke
-          Rake::Task['donut:rspec'].invoke
+          Rake::Task['donut:setup_and_specs'].invoke
         end
       end
     end

--- a/lib/tasks/donut.rake
+++ b/lib/tasks/donut.rake
@@ -8,6 +8,31 @@ unless Rails.env.production?
       t.rspec_opts = ['--color', '--backtrace']
     end
 
+    desc 'Load test config'
+    task :load_test_config do
+      Rails.env = 'test'
+      Settings.reload_from_files(
+        Rails.root.join("config", "settings.yml").to_s,
+        Rails.root.join("config", "settings.local.yml").to_s,
+        Rails.root.join("config", "settings", "test.yml").to_s,
+        Rails.root.join("config", "environments", "test.yml").to_s,
+        Rails.root.join("config", "settings", "test.local.yml").to_s,
+        Rails.root.join("config", "environments", "test.local.yml").to_s
+      )
+    end
+
+    desc 'Seed the test environment and run specs'
+    task :setup_and_specs do
+      %w[
+        donut:load_test_config
+        db:setup
+        zookeeper:upload
+        zookeeper:create
+        elasticsearch:init
+        donut:rspec
+      ].each { |task| Rake::Task[task].invoke }
+    end
+
     desc 'Add admin role to the ENV[\'ADMIN_USER\']'
     task add_admin_role: :environment do
       if ENV['ADMIN_USER']

--- a/lib/tasks/donut.rake
+++ b/lib/tasks/donut.rake
@@ -12,12 +12,12 @@ unless Rails.env.production?
     task :load_test_config do
       Rails.env = 'test'
       Settings.reload_from_files(
-        Rails.root.join("config", "settings.yml").to_s,
-        Rails.root.join("config", "settings.local.yml").to_s,
-        Rails.root.join("config", "settings", "test.yml").to_s,
-        Rails.root.join("config", "environments", "test.yml").to_s,
-        Rails.root.join("config", "settings", "test.local.yml").to_s,
-        Rails.root.join("config", "environments", "test.local.yml").to_s
+        Rails.root.join('config', 'settings.yml').to_s,
+        Rails.root.join('config', 'settings.local.yml').to_s,
+        Rails.root.join('config', 'settings', 'test.yml').to_s,
+        Rails.root.join('config', 'environments', 'test.yml').to_s,
+        Rails.root.join('config', 'settings', 'test.local.yml').to_s,
+        Rails.root.join('config', 'environments', 'test.local.yml').to_s
       )
     end
 


### PR DESCRIPTION
Adds a `rake donut:setup_and_specs` task to make using devstack easier without breaking the standalone docker-stack build.