### PR TITLE
adding in legacy ids field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -162,6 +162,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('scope_and_contents', :stored_searchable), label: 'Scope and Contents'
     config.add_index_field solr_name('series', :stored_searchable), label: 'Series'
     config.add_index_field solr_name('table_of_contents', :stored_searchable), label: 'Table of Contents'
+    config.add_index_field solr_name('legacy_identifier', :stored_searchable), label: 'Legacy Identifier'
 
     # CommonMetadata fields to display in search results
     config.add_index_field solr_name('nul_use_statement', :stored_searchable), label: 'NUL Use Statement'
@@ -233,6 +234,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('box_number', :stored_searchable), label: 'Box Number'
     config.add_show_field solr_name('folder_name', :stored_searchable), label: 'Folder Name'
     config.add_show_field solr_name('folder_number', :stored_searchable), label: 'Folder Number'
+    config.add_show_field solr_name('legacy_identifier', :stored_searchable), label: 'Legacy Identifiers'
 
     # CommonMetadata fields for the single result view
     config.add_show_field solr_name('nul_use_statement', :stored_searchable)

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -32,6 +32,7 @@ module Hyrax
       :folder_number,
       :genre,
       :illustrator,
+      :legacy_identifier,
       :librettist,
       :musician,
       :notes,

--- a/app/models/schemas/common_metadata.rb
+++ b/app/models/schemas/common_metadata.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ModuleLength
 module Schemas
   ##
   # Schema for metadata shared among Work types
@@ -19,6 +20,10 @@ module Schemas
 
     # rubocop:disable Metrics/BlockLength
     included do
+      property :legacy_identifier, predicate: ::Vocab::Donut.legacy_identifier do |index|
+        index.as :stored_searchable
+      end
+
       property :nul_use_statement, predicate: ::RDF::Vocab::DC.accessRights do |index|
         index.as :stored_searchable
       end
@@ -151,4 +156,5 @@ module Schemas
     end
     # rubocop:enable Metrics/BlockLength
   end
+  # rubocop:enable Metrics/ModuleLength
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -130,6 +130,10 @@ class SolrDocument
     fetch(Solrizer.solr_name('genre', :stored_searchable), [])
   end
 
+  def legacy_identifier
+    fetch(Solrizer.solr_name('legacy_identifier', :stored_searchable), [])
+  end
+
   def nul_contributor
     fetch(Solrizer.solr_name('nul_contributor', :stored_searchable), [])
   end

--- a/app/models/vocab/donut.rb
+++ b/app/models/vocab/donut.rb
@@ -17,5 +17,6 @@ module Vocab
     term :donut_exif_version
     term :icc_profile_description
     term :exif_all_data
+    term :legacy_identifier
   end
 end

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -32,6 +32,7 @@ module Hyrax
       :genre_label,
       :illustrator_label,
       :language_label,
+      :legacy_identifier,
       :librettist_label,
       :notes,
       :nul_contributor,

--- a/app/services/common_indexers/image.rb
+++ b/app/services/common_indexers/image.rb
@@ -50,6 +50,7 @@ module CommonIndexers
         related_url: related_url_values,
         rights_statement: rights_statement_object,
         identifier: identifier,
+        legacy_identifier: legacy_identifier,
         license: licenses,
         nul_use_statement: nul_use_statement,
         accession_number: accession_number,

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -20,6 +20,7 @@
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim') %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:language_label, render_as: :faceted, label: 'Language') %>
+<%= presenter.attribute_to_html(:legacy_identifier) %>
 <%= presenter.attribute_to_html(:notes) %>
 <%= presenter.attribute_to_html(:physical_description_material, label: 'Physical Description Material') %>
 <%= presenter.attribute_to_html(:physical_description_size, render_as: :faceted) %>

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
     nul_contributor ['ContribCat']
     box_name ['A good box name']
     box_number ['42']
+    legacy_identifier ['old_images_pid', 'another pid']
     folder_name ['The folder name']
     folder_number ['99']
     preservation_level '1'

--- a/spec/forms/hyrax/image_form_spec.rb
+++ b/spec/forms/hyrax/image_form_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Hyrax::ImageForm do
         :folder_name,
         :folder_number,
         :genre,
+        :legacy_identifier,
         :notes,
         :nul_contributor,
         :nul_creator,

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe SolrDocument do
       folder_name_tesim: ['The folder name'],
       folder_number_tesim: ['99'],
       genre_tesim: ['Postmodern'],
+      legacy_identifier_tesim: ['old_images_pid', 'another_pid'],
       provenance: ['The example provenance'],
       physical_description_size_tesim: ['Wood 6cm x 7cm'],
       rights_holder_tesim: ['Northwestern University Libraries'],

--- a/spec/support/shared_examples/a_model_with_common_metadata.rb
+++ b/spec/support/shared_examples/a_model_with_common_metadata.rb
@@ -14,6 +14,7 @@ RSpec.shared_examples 'a model with common metadata' do
   it { is_expected.to have_editable_property(:editor, RDF::Vocab::MARCRelators.edt) }
   it { is_expected.to have_editable_property(:engraver, RDF::Vocab::MARCRelators.egr) }
   it { is_expected.to have_editable_property(:illustrator, RDF::Vocab::MARCRelators.ill) }
+  it { is_expected.to have_editable_property(:legacy_identifier, Vocab::Donut.legacy_identifier) }
   it { is_expected.to have_editable_property(:librettist, RDF::Vocab::MARCRelators.lbt) }
   it { is_expected.to have_editable_property(:performer, RDF::Vocab::MARCRelators.prf) }
   it { is_expected.to have_editable_property(:photographer, RDF::Vocab::MARCRelators.pht) }


### PR DESCRIPTION
fixes https://github.com/nulib/next-generation-repository/issues/565

i left the legacy identifiers field editable since i figured it'd be nice for users of the app to be able to add/edit without having to go through the devs, but i'm open to changing it  