### PR TITLE
Overrides predicate defined in Hyrax for license

### DIFF
--- a/app/models/schemas/core_metadata.rb
+++ b/app/models/schemas/core_metadata.rb
@@ -8,5 +8,6 @@ module Schemas
     end
     property :keyword, predicate: ::RDF::Vocab::SCHEMA.keywords
     property :language, predicate: ::RDF::Vocab::DC11.language, class_name: ControlledVocabularies::Base
+    property :license, predicate: ::RDF::Vocab::DC.license
   end
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Image do
   it_behaves_like 'a model with image metadata'
   it_behaves_like 'a model with common metadata'
   it_behaves_like 'a model with nul core metadata'
-  it_behaves_like 'a model with hyrax basic metadata', except: [:contributor, :creator, :keyword, :language]
+  it_behaves_like 'a model with hyrax basic metadata', except: [:contributor, :creator, :keyword, :language, :license]
 
   it 'defaults status to Image.DEFAULT_STATUS' do
     attributes = FactoryBot.attributes_for(:image).except(:status)

--- a/spec/support/shared_examples/a_model_with_nul_core_metadata.rb
+++ b/spec/support/shared_examples/a_model_with_nul_core_metadata.rb
@@ -3,4 +3,5 @@ RSpec.shared_examples 'a model with nul core metadata' do
   it { is_expected.to have_editable_property(:creator, RDF::Vocab::DC11.creator) }
   it { is_expected.to have_editable_property(:keyword, RDF::Vocab::SCHEMA.keywords) }
   it { is_expected.to have_editable_property(:language, RDF::Vocab::DC11.language) }
+  it { is_expected.to have_editable_property(:license, RDF::Vocab::DC.license) }
 end


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/627

* changes `license` predicate from `http://purl.org/dc/terms/rights`  to `http://purl.org/dc/terms/license` per spreadsheet: https://docs.google.com/spreadsheets/d/1PBvp9FJAvG6JIP6RZwmiZSDhgYLQ6VRSknUnkodEH8Q/edit#gid=39640035