### PR TITLE
Adds service to write iiif manifest to s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Donut is a Hydra head based on [Hyrax](http://github.com/projecthydra-labs/hyrax
 * Clone the Donut GitHub repository
 * Install dependencies: `bundle install`
 * Run `devstack up donut` in a separate tab to start dependency services
-* Setup the database: `rake db:setup`
-* Generate roles: `rake generate_roles`
 
 * Run `rake donut:seed` to initialize the stack.
   * Optional arguments to `donut:seed` (may be used in combination):

--- a/app/builders/s3_manifest_helper.rb
+++ b/app/builders/s3_manifest_helper.rb
@@ -1,0 +1,28 @@
+# used in order to override build_rendering
+# from Hyrax: https://github.com/samvera/hyrax/blob/master/app/builders/hyrax/manifest_helper.rb
+# to change the @id/url to download the renderings from s3 instead of Donut
+# for use in our public iiif manifests stored on s3
+class S3ManifestHelper
+  # Build a rendering hash
+  #
+  # @return [Hash] rendering
+  def build_rendering(file_set_id)
+    file_set_document = query_for_rendering(file_set_id)
+    original_file = ::FileSet.find(file_set_id).original_file
+    url = IiifDerivativeService.resolve(original_file.id).join('full/full/0/default.jpg')
+    label = file_set_document.label.present? ? ": #{file_set_document.label}" : ''
+    mime = file_set_document.mime_type.present? ? file_set_document.mime_type : I18n.t('hyrax.manifest.unknown_mime_text')
+    {
+      '@id' => url,
+      'format' => mime,
+      'label' => I18n.t('hyrax.manifest.download_text') + label
+    }
+  end
+
+  # Query for the properties to create a rendering
+  #
+  # @return [SolrDocument] query result
+  def query_for_rendering(file_set_id)
+    ::SolrDocument.find(file_set_id)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,6 +31,10 @@ module ApplicationHelper
     link_to(item.created_item, "/concern/#{type}/#{item.created_item}")
   end
 
+  def public_iiif_manifest_linker(id)
+    link_to('Public IIIF Manifest', IiifManifestService.manifest_url(id).to_s, class: 'btn btn-default')
+  end
+
   private
 
     # rubocop:disable Metrics/CyclomaticComplexity

--- a/app/models/s3_manifest_ability.rb
+++ b/app/models/s3_manifest_ability.rb
@@ -1,0 +1,7 @@
+class S3ManifestAbility
+  include CanCan::Ability
+
+  def initialize
+    can :read, :all
+  end
+end

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -1,0 +1,39 @@
+require 'iiif_manifest'
+
+module Hyrax
+  # This gets mixed into FileSetPresenter in order to create
+  # a canvas on a IIIF manifest
+  module DisplaysImage
+    extend ActiveSupport::Concern
+
+    # Creates a display image only where FileSet is an image.
+    #
+    # @return [IIIFManifest::DisplayImage] the display image required by the manifest builder.
+    def display_image
+      return nil unless ::FileSet.exists?(id) && solr_document.image? && current_ability.can?(:read, id)
+      # @todo this is slow, find a better way (perhaps index iiif url):
+      original_file = ::FileSet.find(id).original_file
+
+      url = Hyrax.config.iiif_image_url_builder.call(
+        original_file.id,
+        'http://thisisnotused',
+        Hyrax.config.iiif_image_size_default
+      )
+      # @see https://github.com/samvera-labs/iiif_manifest
+      IIIFManifest::DisplayImage.new(url,
+                                     width: 640,
+                                     height: 480,
+                                     iiif_endpoint: iiif_endpoint(original_file.id))
+    end
+
+    private
+
+      def iiif_endpoint(file_id)
+        return unless Hyrax.config.iiif_image_server?
+        IIIFManifest::IIIFEndpoint.new(
+          Hyrax.config.iiif_info_url_builder.call(file_id, 'http://thisisnotused'),
+          profile: Hyrax.config.iiif_image_compliance_level_uri
+        )
+      end
+  end
+end

--- a/app/presenters/s3_iiif_manifest_presenter.rb
+++ b/app/presenters/s3_iiif_manifest_presenter.rb
@@ -1,0 +1,29 @@
+class S3IiifManifestPresenter < Hyrax::ImagePresenter
+  def manifest_helper
+    @manifest_helper ||= S3ManifestHelper.new
+  end
+
+  # IIIF manifest_url for inclusion in the manifest
+  # called by the iiif_manifest gem
+  def manifest_url
+    IiifManifestService.manifest_url(id)
+  end
+
+  # IIIF metadata for inclusion in the manifest
+  #  Called by the `iiif_manifest` gem to add metadata
+  #
+  # @return [Array] array of metadata hashes
+  def manifest_metadata
+    metadata_fields = [:title, :accession_number, :date_created, :abstract, :creator_label, :subject_topical_label, :rights_statement]
+    metadata = []
+    metadata_fields.each do |field|
+      values = Array.wrap(send(field))
+      next if values.blank?
+      metadata << {
+        'label' => I18n.t("simple_form.labels.defaults.#{field}"),
+        'value' => values
+      }
+    end
+    metadata
+  end
+end

--- a/app/services/common_indexers/image.rb
+++ b/app/services/common_indexers/image.rb
@@ -44,7 +44,7 @@ module CommonIndexers
         subject: typed_values(:subject, [:subject_geographical, 'geographical'], [:subject_topical, 'topical']),
         title: { primary: title, alternate: alternate_title },
         thumbnail_url: representative_file('square/300,/0/default.jpg'),
-        iiif_manifest: representative_file('manifest.json'),
+        iiif_manifest: IiifManifestService.manifest_url(id),
         representative_file_url: representative_file(''),
         resource_type: resource_type,
         related_url: related_url_values,

--- a/app/services/iiif_manifest_service.rb
+++ b/app/services/iiif_manifest_service.rb
@@ -1,0 +1,29 @@
+class IiifManifestService
+  class << self
+    def manifest_url(work_id)
+      Pathname.new(Settings.metadata.endpoint).join(s3_key_for(work_id))
+    end
+
+    def remove_manifest(work_id)
+      obj = Aws::S3::Object.new(Settings.aws.buckets.manifests, s3_key_for(work_id))
+      obj.delete
+    end
+
+    def write_manifest(work_id)
+      presenter = S3IiifManifestPresenter.new(SolrDocument.find(work_id), S3ManifestAbility.new)
+      manifest_json = JSON.pretty_generate(::IIIFManifest::ManifestFactory.new(presenter).to_h)
+      destination = Aws::S3::Object.new(Settings.aws.buckets.manifests, s3_key_for(work_id))
+      destination.put(body: manifest_json, acl: 'public-read')
+    end
+
+    private
+
+      def s3_key_for(work_id)
+        File.join('public', Pathname.new(derivative_path_for(work_id)).relative_path_from(Hyrax.config.derivatives_path).to_s)
+      end
+
+      def derivative_path_for(work_id)
+        Hyrax::DerivativePath.derivative_path_for_reference(work_id, 'manifest').sub!(/manifest$/, 'json')
+      end
+  end
+end

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,0 +1,14 @@
+
+<% if presenter.representative_id.present? && presenter.representative_presenter.present? %>
+  <% if defined?(viewer) && viewer %>
+    <%= PulUvRails::UniversalViewer.script_tag %>
+    <div class="viewer-wrapper">
+      <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter], { locale: nil } %>"></div>
+    </div>
+    <div><%= public_iiif_manifest_linker(presenter.id) %></div>
+  <% else %>
+    <%= media_display presenter.representative_presenter %>
+  <% end %>
+<% else %>
+  <%= image_tag 'default.png', class: "canonical-image" %>
+<% end %>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -116,7 +116,7 @@ Hyrax.config do |config|
 
   # Returns a URL that resolves to an image provided by a IIIF image server
   config.iiif_image_url_builder = lambda do |file_id, _base_url, size|
-    IiifDerivativeService.resolve(file_id, extra_path: "/full/#{size}/0/default.jpg")
+    IiifDerivativeService.resolve(file_id, extra_path: "full/#{size}/0/default.jpg")
   end
   # config.iiif_image_url_builder = lambda do |file_id, base_url, size|
   #   "#{base_url}/downloads/#{file_id.split('/').first}"
@@ -126,6 +126,7 @@ Hyrax.config do |config|
   config.iiif_info_url_builder = lambda do |file_id, _base_url|
     IiifDerivativeService.resolve(file_id)
   end
+
   # config.iiif_info_url_builder = lambda do |_, _|
   #   ""
   # end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -2,6 +2,24 @@ en:
   simple_form:
     labels:
       defaults:
+        alternate_title: Alternate Title
+        accession_number: Accession Number
+        abstract: Abstract
+        ark: ARK
+        based_near_label: Location (Place of Publication) 
+        bibliographic_citation: Citation
+        box_name: Box Name
+        box_number: Box Nunmber
+        call_number: Call Number
+        caption: Caption
+        catalog_key: Catalog Key
+        contributor_label: Contributor
+        creator_label: Creator
+        date_created_display: Date Created
+        related_url: Related URL
+        rights_statement: Rights Statement
+        folder_name: Folder Name
+        folder_number: Folder Number
         description: Description
         nul_creator: Uncontrolled Creator
         nul_contributor: Uncontrolled Contributor

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -8,10 +8,13 @@ aws:
     uploads: dev-uploads
     batch: dev-batch
     pyramids: dev-pyramids
+    manifests: dev-manifests
   queues:
     ingest: donut.fifo
 iiif:
   endpoint: http://localhost:8183/iiif/2/
+metadata:
+  endpoint: http://localhost:9001/dev-manifests/
 common_indexer:
   endpoint: http://localhost:9201/
 solrcloud: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,3 +1,4 @@
+derivatives_path: <%= File.join(ENV['HOME'], '.nuldata', 'derivatives') %>
 localstack:
   sqs: false
   port_offset: 200
@@ -6,8 +7,11 @@ aws:
   buckets:
     batch:   test-batch
     uploads: test-uploads
+    manifests: test-manifests
 common_indexer:
   endpoint: http://localhost:9202/
+metadata:
+  endpoint: http://localhost:9002/test-manifests/
 solrcloud: true
 zookeeper:
   connection_str: "localhost:9985/configs"

--- a/spec/fixtures/files/manifest.json
+++ b/spec/fixtures/files/manifest.json
@@ -1,0 +1,67 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@type": "sc:Manifest",
+  "@id": "http://localhost:9001/minio/dev-manifests/public/bd/5e/d5/15/-4/2b/5-/42/dd/-9/eb/7-/a6/aa/1e/0e/51/34-manifest.json",
+  "label": "Test Image Title a5a01b46-5399-45cc-bad7-b96ca26a200c",
+  "metadata": [
+    {
+      "label": "Title",
+      "value": [
+        "Test Image Title a5a01b46-5399-45cc-bad7-b96ca26a200c"
+      ]
+    },
+    {
+      "label": "Accession Number",
+      "value": [
+        "a5a01b46-5399-45cc-bad7-b96ca26a200c"
+      ]
+    },
+    {
+      "label": "Date Created",
+      "value": [
+        "1983"
+      ]
+    },
+    {
+      "label": "Rights Statement",
+      "value": [
+        "http://rightsstatements.org/vocab/NKC/1.0/"
+      ]
+    }
+  ],
+  "sequences": [
+    {
+      "@type": "sc:Sequence",
+      "@id": "/sequence/normal",
+      "rendering": [],
+      "canvases": [
+        {
+          "@type": "sc:Canvas",
+          "@id": "http://localhost:9001/minio/dev-manifests/public/bd/5e/d5/15/-4/2b/5-/42/dd/-9/eb/7-/a6/aa/1e/0e/51/34-manifest.json/canvas/7dda3297-106a-4bef-a61a-659708028d86",
+          "label": "IMG_1432.JPG",
+          "width": 640,
+          "height": 480,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@type": "dctypes:Image",
+                "@id": "http://localhost:8183/iiif/2/18%2F3a%2F83%2Fb7%2F-f%2F12%2Fb-%2F45%2Fe4%2F-8%2F03%2F4-%2Fdd%2F69%2Fe7%2F9f%2F3b%2Fca/full/600,/0/default.jpg",
+                "height": 480,
+                "width": 640,
+                "format": null,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://localhost:8183/iiif/2/18%2F3a%2F83%2Fb7%2F-f%2F12%2Fb-%2F45%2Fe4%2F-8%2F03%2F4-%2Fdd%2F69%2Fe7%2F9f%2F3b%2Fca",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://localhost:9001/minio/dev-manifests/public/bd/5e/d5/15/-4/2b/5-/42/dd/-9/eb/7-/a6/aa/1e/0e/51/34-manifest.json/canvas/7dda3297-106a-4bef-a61a-659708028d86"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Image do
 
   describe '#to_common_index' do
     it 'maps metadata to a hash for indexing' do
-      expect(image.to_common_index).to be_kind_of(Hash)
+      image_with_id = FactoryBot.build(:image, id: 'abc124')
+      expect(image_with_id.to_common_index).to be_kind_of(Hash)
     end
   end
 end

--- a/spec/models/s3_manifest_ability_spec.rb
+++ b/spec/models/s3_manifest_ability_spec.rb
@@ -1,0 +1,30 @@
+require 'cancan/matchers'
+require 'rails_helper'
+
+RSpec.describe S3ManifestAbility, type: :model do
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:presenter) { Hyrax::FileSetPresenter.new(solr_document, ability) }
+  let(:attributes) { file.to_solr }
+  let(:file) do
+    create(:file_set,
+           id: '123abc',
+           user: user,
+           title: ['File title'],
+           depositor: user.user_key,
+           label: 'filename.tif',
+           visibility: 'restricted')
+  end
+  let(:user) do
+    instance_double(User, user_key: 'testuser1')
+  end
+
+  describe 'without a user' do
+    subject { ability.can?(:read, presenter.id) }
+
+    let(:ability) { S3ManifestAbility.new }
+
+    context 'can read a private FileSet' do
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/services/iiif_manifest_service_spec.rb
+++ b/spec/services/iiif_manifest_service_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe IiifManifestService do
+  let(:attributes) { { id: 'abc123' } }
+  let(:ability) { S3ManifestAbility.new }
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:presenter) { S3IiifManifestPresenter.new(solr_document, ability) }
+  let(:manifest_path) { "#{fixture_path}/files/manifest.json" }
+  let(:bucket) { Aws::S3::Bucket.new(Settings.aws.buckets.manifests) }
+
+  context 'writes to S3' do
+    before do
+      allow(IIIFManifest::ManifestFactory).to receive(:new).and_return(JSON.parse(File.read(manifest_path)))
+      allow(SolrDocument).to receive(:find).with(presenter.id).and_return(solr_document)
+    end
+    let(:instance) { described_class }
+
+    describe '.write_manifest' do
+      it 'writes manifests to the store' do
+        expect { instance.write_manifest(presenter.id) }.to change { bucket.objects.count }.by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
*  Adds `IiifManifestService` that provides a`IiifManifestService.write_manifest(id)` method to write a manifest to an s3 bucket for a given work.

Since we can't figure out the best place to put this at the moment, we're thinking we merge this, and make sure that the parts that actually write the manifest to the buckets work, and the service can be called directly. 