### PR TITLE
update language predicate to match jens spreadsheet

### DIFF
--- a/app/models/schemas/core_metadata.rb
+++ b/app/models/schemas/core_metadata.rb
@@ -7,7 +7,7 @@ module Schemas
       index.as :stored_searchable, :facetable
     end
     property :keyword, predicate: ::RDF::Vocab::SCHEMA.keywords
-    property :language, predicate: ::RDF::Vocab::DC11.language, class_name: ControlledVocabularies::Base
+    property :language, predicate: ::RDF::Vocab::DC.language, class_name: ControlledVocabularies::Base
     property :license, predicate: ::RDF::Vocab::DC.license
   end
 end

--- a/spec/support/shared_examples/a_model_with_nul_core_metadata.rb
+++ b/spec/support/shared_examples/a_model_with_nul_core_metadata.rb
@@ -2,6 +2,6 @@ RSpec.shared_examples 'a model with nul core metadata' do
   it { is_expected.to have_editable_property(:contributor, RDF::Vocab::DC11.contributor) }
   it { is_expected.to have_editable_property(:creator, RDF::Vocab::DC11.creator) }
   it { is_expected.to have_editable_property(:keyword, RDF::Vocab::SCHEMA.keywords) }
-  it { is_expected.to have_editable_property(:language, RDF::Vocab::DC11.language) }
+  it { is_expected.to have_editable_property(:language, RDF::Vocab::DC.language) }
   it { is_expected.to have_editable_property(:license, RDF::Vocab::DC.license) }
 end


### PR DESCRIPTION
fixes https://github.com/nulib/next-generation-repository/issues/673

when saving a record and filling out the language field, the predicate shows up as a dc/terms/language predicate now. 