### PR TITLE
Add a makeshift state machine

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,7 @@ Metrics/ClassLength:
     - 'app/models/solr_document.rb'
     - 'app/models/image.rb'
     - 'app/forms/hyrax/image_form.rb'
+    - 'app/services/common_indexers/base.rb'
 
 Metrics/LineLength:
   Max: 164 # default is 80

--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ group :development, :test do
   gem 'docker-stack'
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
+  gem 'sidekiq'
   gem 'solr_wrapper', '>= 0.3'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1217,6 +1217,8 @@ GEM
       rails (~> 5.0)
       rdf
     rack (2.0.5)
+    rack-protection (2.0.4)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)
@@ -1409,6 +1411,10 @@ GEM
       rdf-xsd (>= 2.2, < 4.0)
       sparql (>= 2.2, < 4.0)
       sxp (~> 1.0)
+    sidekiq (5.2.2)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     signet (0.8.1)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -1550,6 +1556,7 @@ DEPENDENCIES
   rubyzip (~> 1.2.2)
   sass-rails (~> 5.0)
   selenium-webdriver
+  sidekiq
   solr_wrapper (>= 0.3)
   sqlite3
   turbolinks (~> 5)

--- a/app/actors/hyrax/actors/create_with_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_actor.rb
@@ -1,0 +1,54 @@
+module Hyrax
+  module Actors
+    # Creates a work and attaches files to the work
+    class CreateWithFilesActor < Hyrax::Actors::AbstractActor
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if create was successful
+      def create(env)
+        uploaded_file_ids = filter_file_ids(env.attributes.delete(:uploaded_files))
+        files = uploaded_files(uploaded_file_ids)
+        validate_files(files, env) && next_actor.create(env) && attach_files(files, env)
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if update was successful
+      def update(env)
+        uploaded_file_ids = filter_file_ids(env.attributes.delete(:uploaded_files))
+        files = uploaded_files(uploaded_file_ids)
+        validate_files(files, env) && next_actor.update(env) && attach_files(files, env)
+      end
+
+      private
+
+        def filter_file_ids(input)
+          Array.wrap(input).select(&:present?)
+        end
+
+        # ensure that the files we are given are owned by the depositor of the work
+        def validate_files(files, env)
+          expected_user_id = env.user.id
+          files.each do |file|
+            if file.user_id != expected_user_id
+              Rails.logger.error "User #{env.user.user_key} attempted to ingest uploaded_file #{file.id}, but it belongs to a different user"
+              return false
+            end
+          end
+          true
+        end
+
+        # @return [TrueClass]
+        def attach_files(files, env)
+          CrappyStateMachine.trace(job_class: self.class.name, job_id: env.object_id, target_id: env.curation_concern.id, work_id: env.curation_concern.id) do
+            AttachFilesToWorkJob.perform_later(env.curation_concern, files, env.attributes.to_h.symbolize_keys) if files.present?
+            true
+          end
+        end
+
+        # Fetch uploaded_files from the database
+        def uploaded_files(uploaded_file_ids)
+          return [] if uploaded_file_ids.empty?
+          UploadedFile.find(uploaded_file_ids)
+        end
+    end
+  end
+end

--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -10,5 +10,9 @@ module Hyrax
 
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::ImagePresenter
+
+    def status
+      render json: CrappyStateMachine.work_status(params[:id])
+    end
   end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,7 @@
 class ApplicationJob < ActiveJob::Base
   queue_as Hyrax.config.ingest_queue_name
 
-  after_enqueue  { |job| job.transition_state('enqueued')   }
+  before_enqueue  { |job| job.transition_state('queued')   }
   before_perform { |job| job.transition_state('performing') }
   after_perform  { |job| job.transition_state('performed')  }
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,7 @@
 class ApplicationJob < ActiveJob::Base
   queue_as Hyrax.config.ingest_queue_name
 
-  before_enqueue  { |job| job.transition_state('queued')   }
+  before_enqueue { |job| job.transition_state('queued') }
   before_perform { |job| job.transition_state('performing') }
   after_perform  { |job| job.transition_state('performed')  }
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,30 @@
 class ApplicationJob < ActiveJob::Base
   queue_as Hyrax.config.ingest_queue_name
+
+  after_enqueue  { |job| job.transition_state('enqueued')   }
+  before_perform { |job| job.transition_state('performing') }
+  after_perform  { |job| job.transition_state('performed')  }
+
+  def transition_state(state)
+    CrappyStateMachine.transition(job_class: self.class.name,
+                                  target_id: target_and_work[:target_id],
+                                  job_id: job_id,
+                                  work_id: target_and_work[:work_id],
+                                  state: state)
+  end
+
+  private
+
+    def target_and_work
+      @target_and_work ||= ids_for(arguments.first.is_a?(String) ? ActiveFedora::Base.where(id: arguments.first).first : arguments.first)
+    end
+
+    def ids_for(target)
+      case target
+      when Image        then { target_id: target.id, work_id: target.id }
+      when FileSet      then { target_id: target.id, work_id: target&.parent&.id }
+      when JobIoWrapper then { target_id: target.file_set.id, work_id: target.file_set&.parent&.id }
+      else { target_id: nil, work_id: nil }
+      end
+    end
 end

--- a/app/models/crappy_state_machine.rb
+++ b/app/models/crappy_state_machine.rb
@@ -1,0 +1,26 @@
+class CrappyStateMachine < ApplicationRecord
+  class << self
+    def transition(job_class:, job_id:, target_id:, work_id:, state:)
+      return if work_id.nil?
+      csm = where(job_class: job_class, target_id: target_id).first_or_initialize
+      csm.update_attributes(job_id: job_id, work_id: work_id, state: state)
+    end
+
+    def work_status(work_id)
+      { id: work_id, file_sets: {} }.tap do |result|
+        where(work_id: work_id).order(:updated_at).each do |csm|
+          value = { state: csm.state, at: csm.updated_at }
+          if work_id == csm.target_id
+            result[csm.job_class] = value
+          else
+            (result[:file_sets][csm.target_id] ||= {})[csm.job_class] = value
+          end
+        end
+      end
+    end
+
+    def zombies
+      where("(updated_at < :run_age AND state = 'performing') OR (updated_at < :queue_age AND state = 'enqueued')", run_age: 1.day.ago, queue_age: 1.week.ago)
+    end
+  end
+end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -7,4 +7,9 @@ class FileSet < ActiveFedora::Base
   def to_common_index
     CommonIndexService.index(self)
   end
+
+  def processed?
+    file_set_jobs = ['CharacterizeJob', 'CreateDerivativesJob', 'CreatePyramidTiffJob', 'IngestJob']
+    CrappyStateMachine.where(job_class: file_set_jobs, target_id: id, state: 'performed').length == file_set_jobs.length
+  end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -150,7 +150,7 @@ class Image < ActiveFedora::Base
   end
 
   def processed?
-    work_jobs = ['AttachFilesToWorkJob', 'ImportUrlJob']
+    work_jobs = ['Hyrax::Actors::CreateWithFilesActor']
     return false if CrappyStateMachine.where(job_class: work_jobs, target_id: id, state: 'performed').length.zero?
     file_sets.all?(&:processed?)
   end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -149,5 +149,11 @@ class Image < ActiveFedora::Base
     end
   end
 
+  def processed?
+    work_jobs = ['AttachFilesToWorkJob', 'ImportUrlJob']
+    return false if CrappyStateMachine.where(job_class: work_jobs, target_id: id, state: 'performed').length.zero?
+    file_sets.all?(&:processed?)
+  end
+
   apply_schema Schemas::CoreMetadata, Schemas::GeneratedResourceSchemaStrategy.new
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,7 +8,9 @@ default: &default
 
 development:
   <<: *default
+  pool: 1000
   port: 5433
+  timeout: 5000
   database: donut_dev
 
 test:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,5 +58,5 @@ Rails.application.configure do
   # Whitelist the custom dev IP
   config.web_console.whitelisted_ips = '172.16.123.1'
 
-  config.active_job.queue_adapter = :inline
+  config.active_job.queue_adapter = Settings.active_job.queue_adapter || :inline
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,14 @@
+if defined?(Sidekiq)
+  redis_proc = lambda {
+    config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
+    Redis.new(config.merge(thread_safe: true))
+  }
+
+  Sidekiq.configure_client do |config|
+    config.redis = ConnectionPool.new(size: 15, &redis_proc)
+  end
+
+  Sidekiq.configure_server do |config|
+    config.redis = ConnectionPool.new(size: 15, &redis_proc)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,9 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
+  get '/concern/images/:id/status(.:format)', to: 'hyrax/images#status', as: :hyrax_image_status
+  get '/concern/images/:id/public_manifest(.:format)', to: 'hyrax/images#public_manifest', as: :hyrax_image_public_manifest
+
   resources :bookmarks do
     concerns :exportable
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -18,3 +18,5 @@ metadata:
 common_indexer:
   endpoint: http://localhost:9201/
 solrcloud: true
+zookeeper:
+  connection_str: "localhost:9983/configs"

--- a/db/migrate/20181023142014_create_crappy_state_machines.rb
+++ b/db/migrate/20181023142014_create_crappy_state_machines.rb
@@ -1,0 +1,12 @@
+class CreateCrappyStateMachines < ActiveRecord::Migration[5.1]
+  def change
+    create_table :crappy_state_machine do |t|
+      t.string   :job_class, null: false
+      t.string   :job_id, null: false
+      t.string   :target_id, null: false
+      t.string   :work_id
+      t.string   :state
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181023142014_create_crappy_state_machines.rb
+++ b/db/migrate/20181023142014_create_crappy_state_machines.rb
@@ -1,6 +1,6 @@
 class CreateCrappyStateMachines < ActiveRecord::Migration[5.1]
   def change
-    create_table :crappy_state_machine do |t|
+    create_table :crappy_state_machines do |t|
       t.string   :job_class, null: false
       t.string   :job_id, null: false
       t.string   :target_id, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181024175237) do
+ActiveRecord::Schema.define(version: 20181101111812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,6 +162,16 @@ ActiveRecord::Schema.define(version: 20181024175237) do
   create_table "hyrax_features", id: :serial, force: :cascade do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "crappy_state_machines", force: :cascade do |t|
+    t.string "job_class", null: false
+    t.string "job_id", null: false
+    t.string "target_id", null: false
+    t.string "work_id"
+    t.string "state"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,6 +90,16 @@ ActiveRecord::Schema.define(version: 20181101111812) do
     t.string "external_key"
   end
 
+  create_table "crappy_state_machines", force: :cascade do |t|
+    t.string "job_class", null: false
+    t.string "job_id", null: false
+    t.string "target_id", null: false
+    t.string "work_id"
+    t.string "state"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "curation_concerns_operations", id: :serial, force: :cascade do |t|
     t.string "status"
     t.string "operation_type"
@@ -162,16 +172,6 @@ ActiveRecord::Schema.define(version: 20181101111812) do
   create_table "hyrax_features", id: :serial, force: :cascade do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "crappy_state_machines", force: :cascade do |t|
-    t.string "job_class", null: false
-    t.string "job_id", null: false
-    t.string "target_id", null: false
-    t.string "work_id"
-    t.string "state"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/crappy_state_machine_spec.rb
+++ b/spec/models/crappy_state_machine_spec.rb
@@ -5,26 +5,35 @@ RSpec.describe CrappyStateMachine, type: :model do
   let(:job_class) { 'TestJob' }
   let(:job_id) { 'abcde' }
   let(:work_id) { '12345' }
+  let(:common_params) { { job_class: job_class, target_id: file_set_id, work_id: work_id, job_id: job_id } }
 
   describe 'new job' do
     it '#transition' do
-      expect do
-        described_class.transition(job_class: job_class, target_id: file_set_id, work_id: work_id, job_id: job_id, state: 'performing')
-      end.to(change { described_class.count }.by(1))
+      expect { described_class.transition(common_params.merge(state: 'performing')) }.to(change { described_class.count }.by(1))
       expect(described_class.find_by(job_class: job_class, target_id: file_set_id).state).to eq('performing')
     end
   end
 
   describe 'existing job' do
-    before do
-      described_class.transition(job_class: job_class, target_id: file_set_id, work_id: work_id, job_id: job_id, state: 'performing')
-    end
+    before { described_class.transition(common_params.merge(state: 'performing')) }
 
     it '#transition' do
-      expect do
-        described_class.transition(job_class: job_class, target_id: file_set_id, work_id: work_id, job_id: job_id, state: 'performed')
-      end.not_to(change { described_class.count })
+      expect { described_class.transition(common_params.merge(state: 'performed')) }.not_to(change { described_class.count })
       expect(described_class.find_by(job_class: job_class, target_id: file_set_id).state).to eq('performed')
+    end
+  end
+
+  describe '#trace' do
+    it 'without an error' do
+      expect do
+        expect { CrappyStateMachine.trace(common_params) { sleep(1) } }.not_to raise_error
+      end.to(change { described_class.where(job_class: job_class, target_id: file_set_id, state: 'performed').count }.by(1))
+    end
+
+    it 'with an error' do
+      expect do
+        expect { CrappyStateMachine.trace(common_params) { raise 'Die!' } }.to raise_error(RuntimeError)
+      end.to(change { described_class.where(job_class: job_class, target_id: file_set_id, state: 'exception').count }.by(1))
     end
   end
 end

--- a/spec/models/crappy_state_machine_spec.rb
+++ b/spec/models/crappy_state_machine_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe CrappyStateMachine, type: :model do
+  let(:file_set_id) { '67890' }
+  let(:job_class) { 'TestJob' }
+  let(:job_id) { 'abcde' }
+  let(:work_id) { '12345' }
+
+  describe 'new job' do
+    it '#transition' do
+      expect do
+        described_class.transition(job_class: job_class, target_id: file_set_id, work_id: work_id, job_id: job_id, state: 'performing')
+      end.to(change { described_class.count }.by(1))
+      expect(described_class.find_by(job_class: job_class, target_id: file_set_id).state).to eq('performing')
+    end
+  end
+
+  describe 'existing job' do
+    before do
+      described_class.transition(job_class: job_class, target_id: file_set_id, work_id: work_id, job_id: job_id, state: 'performing')
+    end
+
+    it '#transition' do
+      expect do
+        described_class.transition(job_class: job_class, target_id: file_set_id, work_id: work_id, job_id: job_id, state: 'performed')
+      end.not_to(change { described_class.count })
+      expect(described_class.find_by(job_class: job_class, target_id: file_set_id).state).to eq('performed')
+    end
+  end
+end


### PR DESCRIPTION
This PR sprinkles some sugar on top of the actor/job stack to make it possible to interrogate "doneness" better than we could before (though still not perfectly).

- Add a makeshift state machine that automatically transitions when jobs are enqueued and performed
- Add `Image#processed?` and `FileSet#processed?` to check if a specific set of states have transitioned to `performed`

partially fixes https://github.com/nulib/next-generation-repository/issues/758