### PR TITLE
Index date_created and date_modified and other Image model properties in Elasticsearch

### DIFF
--- a/app/services/common_indexers/image.rb
+++ b/app/services/common_indexers/image.rb
@@ -5,7 +5,7 @@ module CommonIndexers
         model,
         fields,
         values(:abstract, :caption, :description, :keyword, :provenance, :publisher, :rights_holder, :source, :visibility),
-        labels(:language, :genre, :style_period, :technique)
+        labels(:based_near, :language, :genre, :style_period, :technique)
       )
     end
 
@@ -31,35 +31,42 @@ module CommonIndexers
 
     def fields
       {
-        id: id,
+        accession_number: accession_number,
         admin_set: { id: admin_set&.id, title: admin_set&.title },
+        bibliographic_citation: bibliographic_citation,
+        box: { name: box_name, number: box_number },
+        call_number: call_number,
+        catalog_key: catalog_key,
         collection: member_of_collections.map { |c| { id: c.id, title: c.title.to_a } }.flatten,
         contributor: contributor,
         creator: typed_values(:creator, :nul_creator),
         date: display_date(date_created),
         expanded_date: date(date_created),
-        year: extract_years(date_created),
-        permalink: ark,
-        subject: typed_values(:subject, [:subject_geographical, 'geographical'], [:subject_topical, 'topical']),
-        title: { primary: title, alternate: alternate_title },
-        thumbnail_url: representative_file('square/300,/0/default.jpg'),
-        iiif_manifest: IiifManifestService.manifest_url(id),
-        representative_file_url: representative_file(''),
-        resource_type: resource_type,
-        related_url: related_url_values,
-        rights_statement: rights_statement_object,
+        folder: { name: folder_name, number: folder_number },
+        full_text: full_text_values,
+        id: id,
         identifier: identifier,
+        iiif_manifest: IiifManifestService.manifest_url(id),
         legacy_identifier: legacy_identifier,
         license: licenses,
+        modified_date: date_modified,
+        notes: notes,
         nul_use_statement: nul_use_statement,
-        accession_number: accession_number,
-        call_number: call_number,
-        catalog_key: catalog_key,
-        bibliographic_citation: bibliographic_citation,
-        box: { name: box_name, number: box_number },
-        folder: { name: folder_name, number: folder_number },
+        permalink: ark,
         physical_description: { material: physical_description_material, size: physical_description_size },
-        full_text: full_text_values
+        related_material: related_material,
+        related_url: related_url_values,
+        representative_file_url: representative_file(''),
+        resource_type: resource_type,
+        rights_statement: rights_statement_object,
+        scope_and_contents: scope_and_contents,
+        series: series,
+        subject: typed_values(:subject, :subject_temporal, [:subject_geographical, 'geographical'], [:subject_topical, 'topical']),
+        table_of_contents: table_of_contents,
+        thumbnail_url: representative_file('square/300,/0/default.jpg'),
+        title: { primary: title, alternate: alternate_title },
+        uploaded_date: date_uploaded,
+        year: extract_years(date_created)
       }
     end
 

--- a/app/services/common_indexers/image.rb
+++ b/app/services/common_indexers/image.rb
@@ -56,7 +56,7 @@ module CommonIndexers
         physical_description: { material: physical_description_material, size: physical_description_size },
         related_material: related_material,
         related_url: related_url_values,
-        representative_file_url: representative_file(''),
+        representative_file_url: representative_file,
         resource_type: resource_type,
         rights_statement: rights_statement_object,
         scope_and_contents: scope_and_contents,
@@ -85,7 +85,7 @@ module CommonIndexers
         { uri: rights_statement.first, label: Hyrax::RightsStatementService.new.label(rights_statement.first) }
       end
 
-      def representative_file(suffix)
+      def representative_file(suffix = '')
         return nil if representative_id.nil?
         fs = ::FileSet.find(representative_id)
         return nil if fs.files.empty?


### PR DESCRIPTION
fixes https://github.com/nulib/next-generation-repository/issues/759

Adds to Elasticsearch indexing:
- `date_modified`
-  `date_uploaded`
-  `related_material`
- `scope_and_contents`
- `series`
- `table_of_contents`
- `based_near` (Location) 
- Adds `subject_temporal` to subject indexing