### PR TITLE
Use original_file instead of files.first for FileSet representative file

### DIFF
--- a/app/services/common_indexers/image.rb
+++ b/app/services/common_indexers/image.rb
@@ -92,7 +92,7 @@ module CommonIndexers
           representative_file(object.representative_id, suffix)
         else
           return nil if object.files.empty?
-          IiifDerivativeService.resolve(object.files.first.id).join(suffix)
+          IiifDerivativeService.resolve(object.original_file.id).join(suffix)
         end
       end
   end


### PR DESCRIPTION
After deploying a solution for https://github.com/nulib/next-generation-repository/issues/779, we discovered you cannot use `file_set.files.first` to obtain the id of the .tif as described here: https://github.com/nulib/next-generation-repository/issues/797

* use `file_set.original_file.id` instead of`file_set.files.first.id`