### PR TITLE
public route for dynamic manifests

### DIFF
--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -10,5 +10,22 @@ module Hyrax
 
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::ImagePresenter
+
+    def public_manifest
+      headers['Access-Control-Allow-Origin'] = '*'
+      respond_to do |wants|
+        wants.json { render json: manifest_builder.to_h }
+        wants.html { render json: manifest_builder.to_h }
+      end
+    end
+
+    private
+
+      def manifest_builder
+        doc = ::SolrDocument.find(params[:id])
+        return {} if doc['visibility_ssi'] == 'restricted'
+        presenter = S3IiifManifestPresenter.new(doc, S3ManifestAbility.new)
+        ::IIIFManifest::ManifestFactory.new(presenter)
+      end
   end
 end

--- a/app/services/common_indexers/image.rb
+++ b/app/services/common_indexers/image.rb
@@ -46,7 +46,7 @@ module CommonIndexers
         full_text: full_text_values,
         id: id,
         identifier: identifier,
-        iiif_manifest: IiifManifestService.manifest_url(id),
+        iiif_manifest: "/concern/images/#{id}/public_manifest.json",
         legacy_identifier: legacy_identifier,
         license: licenses,
         modified_date: sortable_date(date_modified),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
+  get '/concern/images/:id/public_manifest(.:format)', to: 'hyrax/images#public_manifest', as: :hyrax_image_public_manifest
+
   resources :bookmarks do
     concerns :exportable
 


### PR DESCRIPTION
fixes https://github.com/nulib/next-generation-repository/issues/760

* create public route for manifests at `/concern/images/#{id}/public_manifest.json`
* don't show manifests at all for Private works -  but for other manifests - all files (restricted, public, institution) should be present in manifests. (requirements described here: https://github.com/nulib/next-generation-repository/issues/766)