### PR TITLE
Use the FileSet ID for the pyramid TIFF location and IIIF ID

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ group :development, :test do
   gem 'docker-stack'
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
+  gem 'sidekiq'
   gem 'solr_wrapper', '>= 0.3'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1217,6 +1217,8 @@ GEM
       rails (~> 5.0)
       rdf
     rack (2.0.5)
+    rack-protection (2.0.4)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)
@@ -1409,6 +1411,10 @@ GEM
       rdf-xsd (>= 2.2, < 4.0)
       sparql (>= 2.2, < 4.0)
       sxp (~> 1.0)
+    sidekiq (5.2.2)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     signet (0.8.1)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -1550,6 +1556,7 @@ DEPENDENCIES
   rubyzip (~> 1.2.2)
   sass-rails (~> 5.0)
   selenium-webdriver
+  sidekiq
   solr_wrapper (>= 0.3)
   sqlite3
   turbolinks (~> 5)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ the active elastic job gem requires an environment variable to be set otherwise 
 $ export PROCESS_ACTIVE_ELASTIC_JOBS=true
 ```
 
+### Jobs
+
+By default, in development, jobs will run inline. To run jobs async, you can use Sidekiq.
+
+In `development.local.yml` add/change the ActiveJob queue adapter `queue_adapter: :inline` to `queue_adapter: :sidekiq`
+
+```sh
+active_job:
+  queue_adapter: :sidekiq
+```
+
+In a separate terminal tab, start Sidekiq:
+
+```sh
+bundle exec sidekiq
+```
+
 ## Notes on the Docker stack
 
 * You can replace `up` with `daemon` in `docker:dev:up` and `docker:test:up` to run the Docker services in the background

--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -11,7 +11,7 @@ module Hyrax
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::ImagePresenter
 
-    prepend_before_action { params[:id].delete!('/') }
+    prepend_before_action only: [:public_manifest] { params[:id].delete!('/') }
 
     def public_manifest
       headers['Access-Control-Allow-Origin'] = '*'

--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -11,6 +11,8 @@ module Hyrax
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::ImagePresenter
 
+    prepend_before_action { params[:id].delete!('/') }
+
     def public_manifest
       headers['Access-Control-Allow-Origin'] = '*'
       respond_to do |wants|

--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -10,5 +10,22 @@ module Hyrax
 
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::ImagePresenter
+
+    def public_manifest
+      headers['Access-Control-Allow-Origin'] = '*'
+      respond_to do |wants|
+        wants.json { render json: manifest_builder.to_h }
+        wants.html { render json: manifest_builder.to_h }
+      end
+    end
+
+    private
+
+      def manifest_builder
+        doc = ::SolrDocument.find(params[:id])
+        return {} if doc['visibility_ssi'] == 'restricted'
+        presenter = S3IiifManifestPresenter.new(doc, S3ManifestAbility.new)
+        ::IIIFManifest::ManifestFactory.new(presenter)
+      end
   end
 end

--- a/app/jobs/create_pyramid_tiff_job.rb
+++ b/app/jobs/create_pyramid_tiff_job.rb
@@ -7,7 +7,7 @@ class CreatePyramidTiffJob < ApplicationJob
     filename = service.prepare_file(Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath))
 
     image = Vips::Image.new_from_file(filename)
-    write_tiff(image, file_id)
+    write_tiff(image, file_set.id)
   end
 
   private

--- a/app/services/common_indexers/image.rb
+++ b/app/services/common_indexers/image.rb
@@ -85,26 +85,22 @@ module CommonIndexers
         { uri: rights_statement.first, label: Hyrax::RightsStatementService.new.label(rights_statement.first) }
       end
 
-      def representative_file(representative_id)
-        return nil if representative_id.nil?
-        object = ActiveFedora::Base.find(representative_id)
+      def target_file(id, path:)
+        return nil if id.nil?
+        object = ActiveFedora::Base.find(id)
         if object.is_a?(::Image)
-          representative_file(object.representative_id)
+          target_file(object.send(path))
         else
-          return nil if object.files.empty?
-          IiifDerivativeService.resolve(object.original_file.id)
+          IiifDerivativeService.resolve(object.id)
         end
       end
 
-      def thumbnail(thumbnail_id)
-        return nil if thumbnail_id.nil?
-        object = ActiveFedora::Base.find(thumbnail_id)
-        if object.is_a?(::Image)
-          thumbnail(object.thumbnail_id)
-        else
-          return nil if object.files.empty?
-          IiifDerivativeService.resolve(object.original_file.id)
-        end
+      def representative_file(id)
+        target_file(id, path: :representative_id)
+      end
+
+      def thumbnail(id)
+        target_file(id, path: :thumbnail_id)
       end
   end
 end

--- a/app/services/iiif_derivative_service.rb
+++ b/app/services/iiif_derivative_service.rb
@@ -20,7 +20,7 @@ class IiifDerivativeService
     private
 
       def file_part_of(id)
-        id.split(%r{/files/}).last
+        id.split(%r{/files/}).first
       end
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,7 +8,9 @@ default: &default
 
 development:
   <<: *default
+  pool: 1000
   port: 5433
+  timeout: 5000
   database: donut_dev
 
 test:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,5 +58,5 @@ Rails.application.configure do
   # Whitelist the custom dev IP
   config.web_console.whitelisted_ips = '172.16.123.1'
 
-  config.active_job.queue_adapter = :inline
+  config.active_job.queue_adapter = Settings.active_job.queue_adapter || :inline
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,14 @@
+if defined?(Sidekiq)
+  redis_proc = lambda {
+    config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
+    Redis.new(config.merge(thread_safe: true))
+  }
+
+  Sidekiq.configure_client do |config|
+    config.redis = ConnectionPool.new(size: 15, &redis_proc)
+  end
+
+  Sidekiq.configure_server do |config|
+    config.redis = ConnectionPool.new(size: 15, &redis_proc)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
-  get '/concern/images/:id/public_manifest(.:format)', to: 'hyrax/images#public_manifest', as: :hyrax_image_public_manifest
+  get '/public/:id-manifest.json', to: 'hyrax/images#public_manifest', as: :hyrax_image_public_manifest, constraints: { id: %r{[0-9a-zA-Z/-]+} }
 
   resources :bookmarks do
     concerns :exportable

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
+  get '/concern/images/:id/public_manifest(.:format)', to: 'hyrax/images#public_manifest', as: :hyrax_image_public_manifest
+
   resources :bookmarks do
     concerns :exportable
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -14,7 +14,7 @@ aws:
 iiif:
   endpoint: http://localhost:8183/iiif/2/
 metadata:
-  endpoint: http://localhost:9001/dev-manifests/
+  endpoint: http://devbox.library.northwestern.edu/
 common_indexer:
   endpoint: http://localhost:9201/
 solrcloud: true


### PR DESCRIPTION
fixes https://github.com/nulib/next-generation-repository/issues/760
fixes https://github.com/nulib/next-generation-repository/issues/718

* Creates a public route for manifests and adds url to Elasticsearch index. Ex: `"iiif_manifest": "http://devbox.library.northwestern.edu/public/55/ae/ff/31/-c/90/3-/49/99/-8/b5/9-/a6/00/ac/b2/f2/fd-manifest.json"`
    * Manifests are shown for Public/NetId works only - but each manifest will contain ALL FileSets (including private ones)
* Uses `file_set.id` instead of the file id (`file_set.files.first.id`) to name the pyramidal .tif location to get around the issue of the file id not being available at index time.
* Adds sidekiq to development dependencies so that functionality that depends on async jobs can be adequately tested.
   * Jobs will still run inline by default. If you want to use sidekiq:
        - In `development.local.yml`, add/change:
```
active_job:
  queue_adapter: :sidekiq
```

*   Then start sidekiq (in separate tab) `bundle exec sidekiq`

**IMPORTANT** - Deployments need to correspond with this PR on the front end: https://github.com/nulib/next-gen-front-end-react/pull/192 and existing Pyramidal .tif's on S3 will need to be renamed. 