### PR TITLE
Customize metadata array in public manifest

### DIFF
--- a/app/presenters/s3_iiif_manifest_presenter.rb
+++ b/app/presenters/s3_iiif_manifest_presenter.rb
@@ -14,7 +14,7 @@ class S3IiifManifestPresenter < Hyrax::ImagePresenter
   #
   # @return [Array] array of metadata hashes
   def manifest_metadata
-    metadata_fields = [:title, :accession_number, :date_created, :abstract, :creator_label, :subject_topical_label, :rights_statement]
+    metadata_fields = [:ark, :date_created, :creator_label, :rights_statement]
     metadata = []
     metadata_fields.each do |field|
       values = Array.wrap(send(field))

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -5,7 +5,7 @@ en:
         alternate_title: Alternate Title
         accession_number: Accession Number
         abstract: Abstract
-        ark: ARK
+        ark: Permalink
         based_near_label: Location (Place of Publication) 
         bibliographic_citation: Citation
         box_name: Box Name
@@ -15,7 +15,7 @@ en:
         catalog_key: Catalog Key
         contributor_label: Contributor
         creator_label: Creator
-        date_created_display: Date Created
+        date_created: Date Created
         related_url: Related URL
         rights_statement: Rights Statement
         folder_name: Folder Name


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/183

* customize `metadata` array for public manifest