### PR TITLE
Remove /var/log/puma and just log to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,6 @@ RUN chown -R app:staff /usr/local/bundle && \
     chown -R app:staff /var/log/clamav && \
     chown -R app:staff /var/lib/clamav && \
     chown -R app:staff /etc/clamav && \
-    mkdir /var/log/puma && chown root:app /var/log/puma && chmod 0775 /var/log/puma && \
     mkdir /var/run/puma && chown root:app /var/run/puma && chmod 0775 /var/run/puma
 
 USER app

--- a/config/puma_container.rb
+++ b/config/puma_container.rb
@@ -3,5 +3,4 @@ threads 8, 32
 workers `grep -c processor /proc/cpuinfo`
 port ENV.fetch('PORT') { 3000 }
 pidfile '/var/run/puma/puma.pid'
-stdout_redirect '/var/log/puma/puma.log', '/var/log/puma/puma.log', true
 daemonize false


### PR DESCRIPTION
Just let puma write to stdout instead of logging to a file inside the container