### PR TITLE
Remove action removing slashes from id

### DIFF
--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -11,8 +11,6 @@ module Hyrax
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::ImagePresenter
 
-    prepend_before_action only: [:public_manifest] { params[:id].delete!('/') }
-
     def public_manifest
       headers['Access-Control-Allow-Origin'] = '*'
       respond_to do |wants|


### PR DESCRIPTION
`prepend_before_action { params[:id].delete!('/') }` is causing problems for Adam. Removing for now since we're not using yet, @mbklein can reimplement when he's ready.