### PR TITLE
Allow rdc_managers role to see Batch in Admin Dashboard

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -1,5 +1,6 @@
 class BatchesController < Hyrax::MyController
   include Hyrax::Breadcrumbs
+  authorize_resource
 
   def index
     add_breadcrumbs

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,8 +12,9 @@ class Ability
 
   # Define any customized permissions here.
   def custom_permissions
+    can [:index, :show, :detail, :read], Batch if current_user.roles.map(&:name).include?('rdc_managers')
     return unless admin?
-    can [:show], Batch
+    can [:index, :show, :detail, :read], Batch
     can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
     can [:edit, :destroy], ActiveFedora::Base
     can :edit, String

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -16,7 +16,9 @@
   <span class="fa fa-file"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
 <% end %>
 
-<%= menu.nav_link(main_app.batches_path,
-                  data: { turbolinks: false }) do %>
-  <span class="fa fa-copy"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.batches') %></span>
+<% if can? :read, Batch %>
+  <%= menu.nav_link(main_app.batches_path,
+                    data: { turbolinks: false }) do %>
+    <span class="fa fa-copy"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.batches') %></span>
+  <% end %>
 <% end %>

--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
 
     transient do
       # false, true, or Hash with keys for permission_template
-      with_permission_template false
+      with_permission_template { false }
     end
   end
 end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -4,9 +4,9 @@ FactoryBot.define do
       user { FactoryBot.create(:user) }
     end
 
-    id 'test-collection-id'
-    title ['Test title']
-    collection_type_gid 'gid://nextgen/hyrax-collectiontype/1'
+    id { 'test-collection-id' }
+    title { ['Test title'] }
+    collection_type_gid { 'gid://nextgen/hyrax-collectiontype/1' }
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user)

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -1,28 +1,28 @@
 FactoryBot.define do
   factory :image do
-    title ['Test title']
-    alternate_title ['Alternate Title 1']
-    rights_statement ['http://rightsstatements.org/vocab/NKC/1.0/']
-    description ['Test description']
-    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-    abstract ['Lemon drops donut gummi bears carrot cake.']
-    accession_number 'Lgf0825'
-    ark 'ark:/12345/12345'
-    call_number 'W107.8:Am6'
-    caption ['This is the caption seen on the image']
-    catalog_key ['9943338434202441']
-    date_created ['197x']
-    provenance ['The example provenance']
-    physical_description_size ['Wood 6cm x 7cm']
-    rights_holder ['Northwestern University Libraries']
-    nul_creator ['Willie Wildcat']
-    nul_contributor ['ContribCat']
-    box_name ['A good box name']
-    box_number ['42']
-    legacy_identifier ['old_images_pid', 'another pid']
-    folder_name ['The folder name']
-    folder_number ['99']
-    preservation_level '1'
+    title { ['Test title'] }
+    alternate_title { ['Alternate Title 1'] }
+    rights_statement { ['http://rightsstatements.org/vocab/NKC/1.0/'] }
+    description { ['Test description'] }
+    visibility  { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    abstract { ['Lemon drops donut gummi bears carrot cake.'] }
+    accession_number { 'Lgf0825' }
+    ark { 'ark:/12345/12345' }
+    call_number { 'W107.8:Am6' }
+    caption { ['This is the caption seen on the image'] }
+    catalog_key { ['9943338434202441'] }
+    date_created { ['197x'] }
+    provenance { ['The example provenance'] }
+    physical_description_size { ['Wood 6cm x 7cm'] }
+    rights_holder { ['Northwestern University Libraries'] }
+    nul_creator { ['Willie Wildcat'] }
+    nul_contributor { ['ContribCat'] }
+    box_name { ['A good box name'] }
+    box_number { ['42'] }
+    legacy_identifier { ['old_images_pid', 'another pid'] }
+    folder_name { ['The folder name'] }
+    folder_number { ['99'] }
+    preservation_level { '1' }
     date_modified { Hyrax::TimeService.time_in_utc }
     date_uploaded { Time.current.ctime }
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require 'cancan/matchers'
+
+RSpec.describe Ability do
+  subject { described_class.new(current_user) }
+
+  let(:current_user) { FactoryBot.create(:user) }
+  let(:manager_role) { instance_double('Role', name: 'rdc_managers') }
+
+  describe 'a regular user' do
+    it do
+      is_expected.not_to be_able_to :show, Batch
+    end
+  end
+
+  describe 'an admin user' do
+    before { allow(current_user).to receive(:groups).and_return(['admin']) }
+    it do
+      is_expected.to be_able_to :show, Batch
+    end
+  end
+
+  describe "a user with 'rdc_managers' role" do
+    before { allow(current_user).to receive(:roles).and_return([manager_role]) }
+    it do
+      is_expected.to be_able_to :show, Batch
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/733

* Allow users with 'rdc_managers' role to view Batches in Admin Dashboard
* Remove `DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 5.2.`