### PR TITLE
Add missing keyword arg to recursive target_file call

### DIFF
--- a/app/services/common_indexers/image.rb
+++ b/app/services/common_indexers/image.rb
@@ -90,7 +90,7 @@ module CommonIndexers
         return nil if id.nil?
         object = ActiveFedora::Base.find(id)
         if object.is_a?(::Image)
-          target_file(object.send(path))
+          target_file(object.send(path), path: path)
         else
           IiifDerivativeService.resolve(object.id)
         end


### PR DESCRIPTION
Fixes nulib/repodev_planing_and_docs#816