### PR TITLE
Index collection metadata in solr

### DIFF
--- a/app/indexers/donut/collection_indexer.rb
+++ b/app/indexers/donut/collection_indexer.rb
@@ -1,5 +1,5 @@
 module Donut
-  class CollectionIndexer < Hyrax::CollectionIndexer
+  class CollectionIndexer < Hyrax::CollectionWithBasicMetadataIndexer
     def generate_solr_document
       super.tap do |solr_doc|
         if object.thumbnail_id.present?


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/805

* Fixes bug where Collection description (& other metadata) not showing in Donut UI because our Collection indexer was inheriting from `Hyrax::CollectionIndexer` instead of `Hyrax::CollectionWithBasicMetadataIndexer` - so it wasn't being indexed in Solr


** Existing Collections will need to be reindexed before metadata shows....