### PR TITLE
Allow unit_viewers to create single_use_links

### DIFF
--- a/app/controllers/hyrax/single_use_links_controller.rb
+++ b/app/controllers/hyrax/single_use_links_controller.rb
@@ -1,0 +1,52 @@
+# rubocop:disable all
+module Hyrax
+  class SingleUseLinksController < ApplicationController
+    include Blacklight::SearchHelper
+    class_attribute :show_presenter
+    self.show_presenter = Hyrax::SingleUseLinkPresenter
+    before_action :authenticate_user!
+    before_action :authorize_user!
+    # Catch permission errors
+    rescue_from Hydra::AccessDenied, CanCan::AccessDenied, with: :deny_link_access
+
+    def deny_link_access(exception)
+      if current_user&.persisted?
+        redirect_to main_app.root_url, alert: "You do not have sufficient privileges to create links to this document"
+      else
+        session["user_return_to"] = request.url
+        redirect_to new_user_session_url, alert: exception.message
+      end
+    end
+
+    def create_download
+      @su = SingleUseLink.create item_id: params[:id], path: hyrax.download_path(id: params[:id])
+      render plain: hyrax.download_single_use_link_url(@su.download_key)
+    end
+
+    def create_show
+      @su = SingleUseLink.create(item_id: params[:id], path: asset_show_path)
+      render plain: hyrax.show_single_use_link_url(@su.download_key)
+    end
+
+    def index
+      links = SingleUseLink.where(item_id: params[:id]).map { |link| show_presenter.new(link) }
+      render partial: 'hyrax/file_sets/single_use_link_rows', locals: { single_use_links: links }
+    end
+
+    def destroy
+      SingleUseLink.find_by_download_key(params[:link_id]).destroy
+      head :ok
+    end
+
+    private
+
+      def authorize_user!
+         current_ability.can_create_single_use_links? or ( authorize! :edit, params[:id] )
+      end
+
+      def asset_show_path
+        polymorphic_path([main_app, fetch(params[:id]).last])
+      end
+  end
+end
+# rubocop:enable all

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,9 +10,13 @@ class Ability
     end
   end
 
+  def can_create_single_use_links?
+    current_user&.groups&.include?('unit_viewers')
+  end
+
   # Define any customized permissions here.
   def custom_permissions
-    can [:index, :show, :detail, :read], Batch if current_user.roles.map(&:name).include?('rdc_managers')
+    can [:index, :show, :detail, :read], Batch if current_user&.groups&.include?('rdc_managers')
     return unless admin?
     can [:index, :show, :detail, :read], Batch
     can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -1,0 +1,19 @@
+<% provide :page_title, @presenter.page_title %>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-xs-12 col-sm-4">
+      <%= media_display @presenter %>
+      <%= render 'show_actions', presenter: @presenter %>
+      <%= render 'single_use_links', presenter: @presenter if @presenter.editor? or current_ability.can_create_single_use_links? %>
+    </div>
+    <div itemscope itemtype="<%= @presenter.itemtype %>" class="col-xs-12 col-sm-8">
+      <header>
+        <%= render 'file_set_title', presenter: @presenter %>
+      </header>
+
+      <%# TODO: render 'show_descriptions' See https://github.com/samvera/hyrax/issues/1481 %>
+      <%= render 'show_details' %>
+      <%= render 'hyrax/users/activity_log', events: @presenter.events %>
+    </div><!-- /columns second -->
+  </div> <!-- /.row -->
+</div><!-- /.container-fluid -->


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/847

* Overrides Hyrax's `app/controllers/hyrax/single_use_links_controller.rb` and `app/views/hyrax/file_sets/show.html.erb` to allow "unit_viewers" to create `single_use_links`