### PR TITLE
Check that controlled vocab uris in batch are valid format

### DIFF
--- a/app/models/batch_item.rb
+++ b/app/models/batch_item.rb
@@ -89,8 +89,8 @@ class BatchItem < ApplicationRecord
       controlled_attributes.each_with_object({}) do |(k, v), all_errors|
         v.each do |uri|
           next if uri.to_s.strip.empty?
-          unless uri.is_a? RDF::URI
-            all_errors.merge!(k => "Invalid format (URI expected): #{uri}. ") { |_k, o, n| o + n }
+          unless uri.is_a?(RDF::URI) && Donut::VocabularyValidationService.valid?(uri.to_s.strip)
+            all_errors.merge!(k => "Vocabulary uri format not valid: #{uri}. ") { |_k, o, n| o + n }
           end
         end
       end

--- a/app/services/donut/vocabulary_validation_service.rb
+++ b/app/services/donut/vocabulary_validation_service.rb
@@ -1,0 +1,19 @@
+# Validates uris
+# based on: https://github.com/nulib/next-generation-repository/wiki/URI-Construction-for-Controlled-Vocabularies
+module Donut
+  class VocabularyValidationService
+    VOCABULARIES = [
+      %r{^http://vocab.getty.edu/ulan/[0-9]+/?$},
+      %r{^http://vocab.getty.edu/aat/[0-9]+/?$},
+      %r{^http://id.worldcat.org/fast/[1-9]{1}[0-9]+/?$},
+      %r{^http://sws.geonames.org/[0-9]+/?$},
+      %r{^http://id.loc.gov/authorities/names/n{1}[0-9]+/?$},
+      %r{^http://id.loc.gov/authorities/subjects/sh{1}[0-9]+/?$}
+    ].freeze
+
+    def self.valid?(uri)
+      regex = Regexp.union(VOCABULARIES)
+      !regex.match(uri).nil?
+    end
+  end
+end

--- a/spec/models/batch_item_spec.rb
+++ b/spec/models/batch_item_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe BatchItem, :clean, type: :model, admin_set: true do
       batch_item.run
       expect(batch_item.status).to eq('error')
       expect(batch_item.error.keys).to eq([:contributor])
-      expect(batch_item.error).to include(contributor: 'Invalid format (URI expected): Text M. Stringer. Invalid format (URI expected): Ima Also Text. ')
+      expect(batch_item.error).to include(contributor: 'Vocabulary uri format not valid: Text M. Stringer. Vocabulary uri format not valid: Ima Also Text. ')
     end
   end
 

--- a/spec/services/donut/vocabulary_validation_service_spec.rb
+++ b/spec/services/donut/vocabulary_validation_service_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe Donut::VocabularyValidationService do
+  describe '.valid?' do
+    subject { described_class.valid?(uri) }
+
+    context 'with valid uri' do
+      let(:uri) { 'http://vocab.getty.edu/ulan/500180874' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'with valid uri with trailing slash' do
+      let(:uri) { 'http://vocab.getty.edu/ulan/500180874/' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'with an invalid uri' do
+      let(:uri) { 'http://vocab.get.edu/ulan/500180874' }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'with an invalid uri - not a uri' do
+      let(:uri) { 'I am just a string' }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'with an invalid uri - wrong geonames format' do
+      let(:uri) { 'http://www.geonames.org/4891382/' }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'with an invalid uri - extra content at end of uri' do
+      let(:uri) { 'http://sws.geonames.org/4891382/evanston.html' }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'with an invalid uri - subject heading id missing sh' do
+      let(:uri) { 'http://id.loc.gov/authorities/subjects/98004200' }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'with an invalid uri - wrong fast format - just fst + id' do
+      let(:uri) { 'fst001234' }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'with an invalid uri - another wrong fast format - includes fst' do
+      let(:uri) { 'http://id.worldcat.org/fast/fst1919741' }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'with an invalid uri - another wrong fast format - leading zeros' do
+      let(:uri) { 'http://id.worldcat.org/fast/0001919741' }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
fixes https://github.com/nulib/next-generation-repository/issues/717

* Validates that controlled vocabularies only contain uri's in formats described here: https://github.com/nulib/next-generation-repository/wiki/URI-Construction-for-Controlled-Vocabularies