### PR TITLE
Remove deprecated StandardFilterFactory Solr filters from Solr config

### DIFF
--- a/solr/blacklight_conf/schema.xml
+++ b/solr/blacklight_conf/schema.xml
@@ -308,7 +308,6 @@
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.StandardFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
@@ -317,7 +316,6 @@
     <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
        <analyzer>
           <tokenizer class="solr.KeywordTokenizerFactory"/>
-          <filter class="solr.StandardFilterFactory"/>
           <filter class="solr.LowerCaseFilterFactory"/>
           <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
        </analyzer>

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -164,17 +164,6 @@
         <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
       </analyzer>
     </fieldType>
-
-    <!--
-    <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.StandardFilterFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-      </analyzer>
-    </fieldType>
-    -->
   </types>
 
 


### PR DESCRIPTION
`StandardFilterFactory` filters were deprecated in Solr 7. Removing these filters will prevent an error when upgrading to Solr 8. See https://github.com/projectblacklight/blacklight/pull/2017 for more information.