### PR TITLE
Fixed deprecation warning: discard_flash_if_xhr

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   helper Openseadragon::OpenseadragonHelper
   # Adds a few additional behaviors into the application controller
   include Blacklight::Controller
+  skip_after_action :discard_flash_if_xhr
   include Hydra::Controller::ControllerBehavior
 
   # Adds Hyrax behaviors into the application controller


### PR DESCRIPTION
Removes `discard_flash_if_xhr` Blacklight deprecation warning prior to upgrading to blacklight 7.x