### PR TITLE
Only index collections of type NUL Collection in Elasticsearch Image documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Donut is a Hydra head based on [Hyrax](http://github.com/projecthydra-labs/hyrax
 * [Geonames user registration](http://www.geonames.org/manageaccount)
   * For local development, add the registered user to `settings.local.yml` with the `geonames_username` key, e.g. `geonames_username: geonames_test_user`
 * Add local fits path to `/config/settings/local.yml`
+* Donut only wants "NUL Collection" types to be public. Add the gid of the collection type you want to index in Elasticsearch to your `config/settings/development.local.yml`. Ex: `nul_collection_type: gid://nextgen/hyrax-collectiontype/3`. 
 
   ```
   fits:

--- a/app/services/common_indexers/image.rb
+++ b/app/services/common_indexers/image.rb
@@ -37,7 +37,7 @@ module CommonIndexers
         box: { name: box_name, number: box_number },
         call_number: call_number,
         catalog_key: catalog_key,
-        collection: member_of_collections.map { |c| { id: c.id, title: c.title.to_a } }.flatten,
+        collection: nul_collections,
         contributor: contributor,
         creator: typed_values(:creator, :nul_creator),
         create_date: sortable_date(create_date),
@@ -72,6 +72,10 @@ module CommonIndexers
     end
 
     private
+
+      def nul_collections
+        member_of_collections.select { |c| c.collection_type_gid == Settings.nul_collection_type }.map { |c| { id: c.id, title: c.title.to_a } }
+      end
 
       def licenses
         [].tap do |obj|


### PR DESCRIPTION
* Only indexes collection information on the Image document in Elasticsearch if the collection is of the type that matches the `Settings.nul_collection_type`

