### PR TITLE
Only index a collection if its an NUL collection

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -9,6 +9,6 @@ class Collection < ActiveFedora::Base
   self.indexer = Donut::CollectionIndexer
 
   def to_common_index
-    CommonIndexService.index(self)
+    CommonIndexService.index(self) if collection_type_gid == Settings.nul_collection_type
   end
 end

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -16,3 +16,4 @@ solrcloud: true
 zookeeper:
   connection_str: "localhost:9985/configs"
 aws_region: us-east-1
+nul_collection_type: gid://nextgen/hyrax-collectiontype/1


### PR DESCRIPTION
* Just don't index Collections that aren't "NUL Collection/s" at all rather than relying on Glaze to filter them out.

* This is instead of this: https://github.com/nulib/next-gen-front-end-react/commit/d2d233f86458bbb0d8807b27ba0eafb5ba7120ff

since staging and prod are named differently....