### PR TITLE
244 public works

### DIFF
--- a/app/controllers/visibility_controller.rb
+++ b/app/controllers/visibility_controller.rb
@@ -1,0 +1,10 @@
+class VisibilityController < ApplicationController
+  def make_public
+    @collection = Collection.find(params[:id])
+    authorize! :edit, @collection
+    PublicCollectionJob.perform_later(@collection.id)
+    redirect_to Hyrax::Engine.routes.url_helpers.dashboard_collection_path(@collection),
+                notice: 'Job submitted. Please be patient; it may take some time to complete.'\
+                        'Refresh this page to see the visibility of the collection members change.'
+  end
+end

--- a/app/controllers/visibility_controller.rb
+++ b/app/controllers/visibility_controller.rb
@@ -1,10 +1,16 @@
 class VisibilityController < ApplicationController
   def make_public
-    @collection = Collection.find(params[:id])
-    authorize! :edit, @collection
-    PublicCollectionJob.perform_later(@collection.id)
-    redirect_to Hyrax::Engine.routes.url_helpers.dashboard_collection_path(@collection),
+    collection = Collection.find(params[:id])
+    authorize! :edit, collection
+    PublicCollectionJob.perform_later(collection_params)
+    redirect_to Hyrax::Engine.routes.url_helpers.dashboard_collection_path(collection),
                 notice: 'Job submitted. Please be patient; it may take some time to complete.'\
                         'Refresh this page to see the visibility of the collection members change.'
   end
+
+  private
+
+    def collection_params
+      params.require(:id)
+    end
 end

--- a/app/jobs/public_collection_job.rb
+++ b/app/jobs/public_collection_job.rb
@@ -1,0 +1,7 @@
+class PublicCollectionJob < ApplicationJob
+  def perform(*collection_ids)
+    Image.find_each(member_of_collection_ids_ssim: collection_ids, visibility_ssi: ['restricted', 'authenticated']) do |image|
+      PublicImageJob.perform_later(image)
+    end
+  end
+end

--- a/app/jobs/public_image_job.rb
+++ b/app/jobs/public_image_job.rb
@@ -1,0 +1,13 @@
+class PublicImageJob < ApplicationJob
+  def perform(image)
+    return if image.visibility == 'open'
+
+    image.visibility = 'open'
+    image.save
+    image.file_sets.each do |fs|
+      next if fs.visibility == 'open'
+      fs.visibility = 'open'
+      fs.save
+    end
+  end
+end

--- a/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
@@ -1,0 +1,34 @@
+<h2 class="sr-only"><%= t('hyrax.collection.actions.header') %></h2>
+<div class="text-right">
+  <% if can? :deposit, presenter.solr_document %>
+    <div>
+      <%= link_to "Make Images Public", main_app.publicize_images_path(presenter.id), 
+        method: :post, 
+        class: 'btn btn-primary', 
+        data: { 
+          confirm: "You are about to change the visibility on all items in this collection. This may take several hours depending on the size of the collection. Please wait until the process finishes before clicking this button again." 
+        }
+      %>
+    </div>
+    <div>
+      <% if @presenter.create_many_work_types? %>
+        <%= link_to t('hyrax.collection.actions.add_new_work.label'),
+                    '#',
+                    title: t('hyrax.collection.actions.add_new_work.desc'),
+                    data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single', add_works_to_collection: presenter.id },
+                    class: 'btn btn-primary deposit-new-work-through-collection' %>
+      <% else # simple link to the first work type %>
+        <%= link_to t('hyrax.collection.actions.add_new_work.label'),
+                    new_polymorphic_path([main_app, @presenter.first_work_type], add_works_to_collection: presenter.id),
+                    class: 'btn btn-primary' %>
+      <% end %>
+    </div>
+    <div>
+      <%= link_to t('hyrax.collection.actions.add_existing_works.label'),
+                  hyrax.my_works_path(add_works_to_collection: presenter.id, add_works_to_collection_label: presenter.title),
+                  title: t('hyrax.collection.actions.add_existing_works.desc'),
+                  class: 'btn btn-link side-arrows',
+                  data: { turbolinks: false } %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
@@ -10,6 +10,7 @@
         }
       %>
     </div>
+    <br/>
     <div>
       <% if @presenter.create_many_work_types? %>
         <%= link_to t('hyrax.collection.actions.add_new_work.label'),
@@ -23,6 +24,7 @@
                     class: 'btn btn-primary' %>
       <% end %>
     </div>
+    <br/>
     <div>
       <%= link_to t('hyrax.collection.actions.add_existing_works.label'),
                   hyrax.my_works_path(add_works_to_collection: presenter.id, add_works_to_collection_label: presenter.title),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,5 +47,5 @@ Rails.application.routes.draw do
     end
   end
 
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  post '/publicize_images/:id', to: 'visibility#make_public', as: :publicize_images
 end

--- a/spec/controllers/visibility_controller_spec.rb
+++ b/spec/controllers/visibility_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe VisibilityController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  let(:admin) { FactoryBot.create(:admin) }
+  let(:collection) { FactoryBot.create(:collection, user: admin) }
+
+  describe 'POST #make_public' do
+    context 'as a user that can edit the collection' do
+      before do
+        sign_in admin
+      end
+
+      it 'returns a success message' do
+        post :make_public, params: { id: collection.id }
+        expect(response.status).to equal(302)
+        expect(flash[:notice]).to include('Job submitted.')
+      end
+    end
+
+    context 'as a user that cannot edit the collection' do
+      before do
+        sign_in user
+      end
+
+      it 'returns an unauthorized message' do
+        post :make_public, params: { id: collection.id }
+        expect(response.status).to equal(401)
+      end
+    end
+  end
+end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     description { ['Test description'] }
     visibility  { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     abstract { ['Lemon drops donut gummi bears carrot cake.'] }
-    accession_number { 'Lgf0825' }
+    sequence(:accession_number) { |n| "accession_#{n}" }
     ark { 'ark:/12345/12345' }
     call_number { 'W107.8:Am6' }
     caption { ['This is the caption seen on the image'] }

--- a/spec/jobs/public_collection_job_spec.rb
+++ b/spec/jobs/public_collection_job_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe PublicCollectionJob do
+  let(:open_image) { FactoryBot.create(:image) }
+  let(:restricted_image) { FactoryBot.create(:image, visibility: 'restricted') }
+  let(:authenticated_image) { FactoryBot.create(:image, visibility: 'authenticated') }
+  let(:collection) { FactoryBot.build(:collection) }
+
+  before do
+    collection.add_member_objects [open_image.id, restricted_image.id, authenticated_image.id]
+    collection.save!
+  end
+
+  it 'enqueues PublicImageJob jobs for restricted and authenticated images' do
+    ActiveJob::Base.queue_adapter = :test
+    expect { described_class.perform_now(collection.id) }.to enqueue_job(PublicImageJob).twice
+  end
+end

--- a/spec/jobs/public_image_job_spec.rb
+++ b/spec/jobs/public_image_job_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe PublicImageJob do
+  let(:image) { FactoryBot.build(:image, visibility: 'restricted') }
+  let(:file_set) { FactoryBot.create(:file_set, visibility: 'restricted') }
+
+  before do
+    image.ordered_members << file_set
+    image.save!
+  end
+
+  it 'sets the visibility of an image and its FileSet members to open' do
+    described_class.perform_now(image)
+    expect(image.visibility).to eq 'open'
+    expect(file_set.visibility).to eq 'open'
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ require 'rake'
 require 'hyrax/spec/matchers'
 require 'hyrax/spec/shared_examples'
 require 'webmock/rspec'
+require 'devise'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -88,4 +89,6 @@ RSpec.configure do |config|
   config.after(:each, type: :feature) do
     Warden.test_reset!
   end
+
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end


### PR DESCRIPTION
To test the feature, go to the Collections dashboard page, choose a collection and click the "Make Images Public" button. It should kick off jobs that change the visibility of each `restricted` or `authenticated` Image and its FileSets to `open`.