### PR TITLE
Set the date_modified on visibility change

### DIFF
--- a/app/jobs/image_visibility_job.rb
+++ b/app/jobs/image_visibility_job.rb
@@ -3,6 +3,7 @@ class ImageVisibilityJob < ApplicationJob
     return if image.visibility == visibility
 
     image.visibility = visibility
+    image.date_modified = Hyrax::TimeService.time_in_utc
     image.save
     image.file_sets.each do |fs|
       next if fs.visibility == visibility

--- a/spec/jobs/image_visibility_job_spec.rb
+++ b/spec/jobs/image_visibility_job_spec.rb
@@ -14,4 +14,10 @@ RSpec.describe ImageVisibilityJob do
     expect(image.visibility).to eq 'open'
     expect(file_set.visibility).to eq 'open'
   end
+
+  it 'changes `date_modified` of an image' do
+    previous_date_modified = image.date_modified
+    described_class.perform_now(image, 'authenticated')
+    expect(image.date_modified).not_to eq previous_date_modified
+  end
 end


### PR DESCRIPTION
- Manually set image `date_modified` during `ImageVisibilityJob`
- Fixes issue where Glaze "Recently added and updated items" does not contain works which had visibility updated using the change image visibility job. 