### PR TITLE
Check for supported methods while expanding dates during index

### DIFF
--- a/app/services/common_indexers/base.rb
+++ b/app/services/common_indexers/base.rb
@@ -1,4 +1,3 @@
-
 module CommonIndexers
   class Base
     attr_reader :source
@@ -22,11 +21,15 @@ module CommonIndexers
     end
 
     def date(edtf_date)
-      all_dates(edtf_date).map(&:iso8601)
+      all_dates(edtf_date).map do |date|
+        date.iso8601 if date.respond_to?(:iso8601)
+      end.uniq.compact
     end
 
     def extract_years(edtf_date)
-      all_dates(edtf_date).map(&:year).uniq
+      all_dates(edtf_date).map do |date|
+        date.year if date.respond_to?(:year)
+      end.uniq.compact
     end
 
     def display_date(edtf_date)
@@ -35,6 +38,7 @@ module CommonIndexers
 
     def sortable_date(date_field)
       return if date_field.nil?
+
       if date_field.respond_to?(:iso8601)
         date_field.iso8601
       else
@@ -85,6 +89,7 @@ module CommonIndexers
           (name, type) = field.is_a?(Array) ? field.map(&:to_s) : [field.to_s, field.to_s]
 
           next if source[name].blank?
+
           Array(source[name]).each do |value|
             (uri, label) = fetch_uri_and_label(value)
             result << { role: type, uri: uri, label: label }
@@ -99,6 +104,7 @@ module CommonIndexers
           (name, type) = field.is_a?(Array) ? field.map(&:to_s) : [field.to_s, field.to_s]
 
           next if source[name].blank?
+
           Array(source[name]).each do |value|
             (uri, label) = fetch_uri_and_label(value)
             result << { role: type, uri: uri, label: "#{label} (#{label_qualifier(type)})" }


### PR DESCRIPTION
- "uuuu" is an `EDTF::Unknown` type and throws an error when you try to call `iso8601` or `year` during expansion for `expanded_date` and `year` fields.

- I'm not sure we're using the expanded date/year at all. I think we initially used the year for the date slider, which has been removed. I'll start a discussion in the issue about whether we can remove these completely but for now they just won't have a value when the date is unknown - which I think makes sense since the date is unknown. 