### PR TITLE
Add agentless SSO using omniauth-nusso strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
 .env
+config/ssl

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'rails', '~> 5.1.1'
 gem 'pg'
 gem 'sqlite3'
 # Use Puma as the app server
-gem 'puma', '~> 3.7'
+gem 'puma', '~> 4.1'
 # Use SCSS for stylesheets
 gem 'bootstrap-sass', '>= 3.4.1'
 gem 'sass-rails', '~> 5.0'
@@ -44,7 +44,7 @@ gem 'ezid-client'
 gem 'honeybadger', '~> 4.0'
 gem 'httparty'
 gem 'hydra-role-management'
-gem 'omniauth-openam'
+gem 'omniauth-nusso', '>= 0.1.1'
 
 gem 'common_indexer', '~> 0.3'
 gem 'donut-retry', github: 'nulib/donut-retry', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1281,12 +1281,12 @@ GEM
       activesupport
       nokogiri (>= 1.4.2)
       solrizer (~> 3.3)
-    omniauth (1.9.0)
-      hashie (>= 3.4.6, < 3.7.0)
+    omniauth (1.9.1)
+      hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-    omniauth-openam (1.1.0)
+    omniauth-nusso (0.1.1)
       faraday
-      omniauth (~> 1.0)
+      omniauth
     openseadragon (0.5.0)
       rails (> 3.2.0)
     orm_adapter (0.5.0)
@@ -1308,7 +1308,8 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.1.1)
     pul_uv_rails (2.0.1)
-    puma (3.12.0)
+    puma (4.3.3)
+      nio4r (~> 2.0)
     qa (3.0.0)
       activerecord-import
       deprecation
@@ -1637,11 +1638,11 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   nulib_microservices!
-  omniauth-openam
+  omniauth-nusso (>= 0.1.1)
   pg
   pry-byebug
   pry-rails
-  puma (~> 3.7)
+  puma (~> 4.1)
   rails (~> 5.1.1)
   redis-rails
   rsolr (>= 1.0)
@@ -1661,4 +1662,4 @@ DEPENDENCIES
   zk
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -8,13 +8,11 @@ Donut is a Hydra head based on [Hyrax](http://github.com/projecthydra-labs/hyrax
 
 - Ruby (version `2.0.4` is known to work)
   - you can use [`rbenv`](https://github.com/rbenv/rbenv) or [`rvm`](https://rvm.io/) to install Ruby
-- [Local authentication configuration](https://github.com/nulib/donut/wiki/Authentication-setup-for-dev-environment)
+- Follow the [Dev Environment Setup](http://docs.rdc.library.northwestern.edu/2._Developer_Guides/Environment_and_Tools/Developer-Tools---Dev-Environment-Setup/#setup) instructions
 - Docker (we're using docker for mac: https://www.docker.com/docker-mac)
 - Install [`devstack`](https://github.com/nulib/devstack) according to the instructions in the README
 - [Geonames user registration](http://www.geonames.org/manageaccount)
-  - For local development, add the registered user to `settings.local.yml` with the `geonames_username` key, e.g. `geonames_username: geonames_test_user`
-- Add local fits path to `/config/settings/local.yml`
-- Obtain a `config/settings/development.local.yml` file from another NU Dev
+  - The `geonames_username` key is defined in our shared configuration file.
 - Fits > 1.0.5 `brew install fits`
 - Vips `brew install vips`
 
@@ -48,7 +46,7 @@ export AWS_PROFILE=fake
 bundle exec rails s
 ```
 
-Donut should be live at: http://devbox.library.northwestern.edu/
+Donut should be live at: https://devbox.library.northwestern.edu:3000/
 
 ## Stopping the application
 
@@ -163,6 +161,6 @@ $ export PROCESS_ACTIVE_ELASTIC_JOBS=true
 ## Adding an Admin user and assigning workflow roles
 
 1.  Run the development servers with `rake docker:dev:up` (or `daemon`) and `rails s`
-1.  Go to http://devbox.library.northwestern.edu/ and login with OpenAM
-1.  To make the user who logged in an admin, run `rake donut:add_admin_role ADMIN_USER[your NetID]`
-1.  Go to http://devbox.library.northwestern.edu/admin/workflow_roles and grant workflow roles if needed
+2.  Go to https://devbox.library.northwestern.edu:3000/ and login
+3.  To make the user who logged in an admin, run `rake donut:add_admin_role ADMIN_USER[your NetID]`
+4.  Go to https://devbox.library.northwestern.edu:3000/admin/workflow_roles and grant workflow roles if needed

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,7 +4,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   skip_before_action :verify_authenticity_token
 
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-  def openam
+  def nusso
     @user = User.from_omniauth(request.env['omniauth.auth'])
     if @user.persisted?
       flash[:success] = I18n.t('devise.omniauth_callbacks.success')

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,6 @@
 class Users::SessionsController < Devise::SessionsController
   def new
-    redirect_to user_omniauth_authorize_path(:openam)
+    redirect_to user_omniauth_authorize_path(:nusso)
   end
 
   def destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   include Blacklight::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :omniauthable, omniauth_providers: [:openam]
+  devise :omniauthable, omniauth_providers: [:nusso]
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :openam, 'https://websso.it.northwestern.edu/amserver', cookie_name: 'openAMssoToken'
+  provider :nusso,
+           'https://northwestern-prod.apigee.net/agentless-websso/',
+           Settings.nusso.consumer_key
 end

--- a/config/puma/development.rb
+++ b/config/puma/development.rb
@@ -1,0 +1,1 @@
+bind 'ssl://127.0.0.1:3000?key=/usr/local/etc/devbox_ssl/devbox.library.key.pem&cert=/usr/local/etc/devbox_ssl/devbox.library.full.pem'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,8 @@ Rails.application.routes.draw do
   devise_scope :user do
     get '/users/sign_in', to: 'users/sessions#new', as: :new_user_session
     delete '/users/sign_out', to: 'users/sessions#destroy', as: :destroy_user_session
-    match '/users/auth/:provider', to: 'users/omniauth_callbacks#user', as: :user_omniauth_authorize, via: [:get, :post]
-    match '/users/auth/openam/callback', controller: 'users/omniauth_callbacks', as: :user_omniauth_callback, via: [:get, :post]
+    get '/users/auth/:provider', to: 'users/omniauth_callbacks#user', as: :user_omniauth_authorize
+    get '/users/auth/nusso/callback', controller: 'users/omniauth_callbacks', as: :user_omniauth_callback
   end
   mount Hydra::RoleManagement::Engine => '/'
   mount Qa::Engine => '/authorities'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -5,7 +5,7 @@ localstack:
 aws:
   endpoint: http://localhost:9002
   buckets:
-    batch:   test-batch
+    batch: test-batch
     uploads: test-uploads
     manifests: test-manifests
 common_indexer:
@@ -17,3 +17,5 @@ zookeeper:
   connection_str: "localhost:9985/configs"
 aws_region: us-east-1
 nul_collection_type: gid://nextgen/hyrax-collectiontype/1
+nusso:
+  consumer_key: test-key


### PR DESCRIPTION
- Adds [`omniauth-nusso`](https://github.com/nulib/omniauth-nusso) along with updated routes and callbacks_controller
- Removes `omniauth-openam`
- Updates README for `config/ssl` instructions to run SSL locally
- Upgrade puma to `4.3.3`, includes `config/puma/development.rb` configuration to run SSL locally
