### PR TITLE
Update common_indexer gem to v0.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -923,7 +923,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    common_indexer (0.5.0)
+    common_indexer (0.5.1)
       active-fedora
       activesupport
       dry-configurable


### PR DESCRIPTION
See https://github.com/nulib/common-indexer/pull/11 for more information about `common_indexer v0.5.1`