### PR TITLE
Update omniauth-nusso to v0.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'ezid-client'
 gem 'honeybadger', '~> 4.0'
 gem 'httparty'
 gem 'hydra-role-management'
-gem 'omniauth-nusso', '>= 0.1.2'
+gem 'omniauth-nusso', '>= 0.1.3'
 
 gem 'common_indexer', '~> 0.5'
 gem 'donut-retry', github: 'nulib/donut-retry', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1284,7 +1284,7 @@ GEM
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-    omniauth-nusso (0.1.2)
+    omniauth-nusso (0.1.3)
       faraday
       omniauth
     openseadragon (0.5.0)
@@ -1639,7 +1639,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   nulib_microservices!
-  omniauth-nusso (>= 0.1.2)
+  omniauth-nusso (>= 0.1.3)
   pg
   pry-byebug
   pry-rails


### PR DESCRIPTION
Updating `omniauth-nusso` to `0.1.3` will prevent JSON parsing errors from directory search responses. See https://github.com/nulib/omniauth-nusso/pull/1 for more information.