### PR TITLE
Add additional fields to FileSet index

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,6 +101,7 @@ RSpec/ExampleLength:
   Exclude:
     - 'spec/app/batch/importer/factory/image_factory_spec.rb'
     - 'spec/forms/hyrax/image_form_spec.rb'
+    - 'spec/services/common_indexers/file_set_spec.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude: 

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'hydra-derivatives', github: 'nulib/hydra-derivatives', branch: 'vips'
 gem 'hyrax', github: 'nulib/hyrax', branch: '2.4.1-plus-be'
 gem 'nulib_microservices', github: 'nulib/nulib_microservices'
+gem 'qa', '>= 5.5.1'
 gem 'solrizer', '>= 3.4', '< 5'
 
 gem 'config'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1650,6 +1650,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 4.1)
+  qa (>= 5.5.1)
   rails (~> 5.1.1)
   redis-rails
   rsolr (>= 1.0)

--- a/app/services/common_indexers/file_set.rb
+++ b/app/services/common_indexers/file_set.rb
@@ -4,9 +4,19 @@ module CommonIndexers
       return {} if files.empty?
       multi_merge(
         model,
-        { id: files.first.id.split(%r{/}).last },
-        values(:label, :description, :visibility)
+        {
+          id: files.first.id.split(%r{/}).last,
+          digest: digest_from_content,
+          simple_title: title
+        },
+        values(:label, :description, :height, :mime_type,
+               :original_checksum, :width, :visibility)
       )
+    end
+
+    def digest_from_content
+      return unless original_file
+      original_file.digest.first.to_s
     end
   end
 end

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -10,6 +10,8 @@ aws:
     manifests: test-manifests
 common_indexer:
   endpoint: http://localhost:9202/
+iiif:
+  endpoint: http://localhost:8183/iiif/2/
 metadata:
   endpoint: http://localhost:9002/test-manifests/
 solrcloud: true

--- a/spec/services/common_indexers/file_set_spec.rb
+++ b/spec/services/common_indexers/file_set_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe CommonIndexers::FileSet do
+  let(:file) { 'world.png' }
+  let(:file_path) { "#{fixture_path}/images/#{file}" }
+  let(:image) { FactoryBot.build(:image).tap(&:save) }
+  let(:file_set) { FactoryBot.build(:file_set).tap(&:save) }
+  let(:collection) { FactoryBot.build(:collection).tap(&:save) }
+  let(:doc) { described_class.new(file_set).generate }
+
+  before do
+    file_set.label = file
+    file_set.title = [file]
+    Hydra::Works::AddFileToFileSet.call(file_set, File.open(file_path, 'rb'), :original_file)
+
+    image.ordered_members << file_set
+    image.member_of_collections << collection
+    image.save!
+  end
+
+  describe '#generate' do
+    it 'includes all expected fields' do
+      expect(doc[:digest]).to match(/^urn:sha1:[0-9a-f]{40}$/)
+      expect(doc[:id]).to match(/^[0-9a-f-]{36}$/)
+      expect(doc[:label]).to eq(file)
+      expect(doc[:mime_type]).to eq('image/png')
+      expect(doc[:model]).to eq(application: 'Nextgen', name: 'FileSet')
+      expect(doc[:simple_title]).to eq([file])
+      expect(doc[:visibility]).to eq('restricted')
+    end
+  end
+end


### PR DESCRIPTION
This PR adds `digest`, `simple_title`, `height`, `width`, `mime_type`, and `original_checksum` to the common index for FileSets. `simple_title` is used instead of `title`, because the mapping expects `title` to be a complex field (with a `primary` and an `alternate`), and that doesn't apply to FileSets.