### PR TITLE
Replace 'u' with 'X' in EDTF dates during migration

### DIFF
--- a/app/services/donut/migration_service.rb
+++ b/app/services/donut/migration_service.rb
@@ -173,7 +173,7 @@ module Donut
       def descriptive_metadata(image)
         {}.tap do |descriptive_metadata|
           descriptive_metadata['date_created'] =
-            image.date_created.map { |d| { edtf: Date.edtf(d).edtf } }
+            image.date_created.map { |d| { edtf: Date.edtf(d).edtf.tr('u', 'X') } }
           descriptive_metadata['contributor'] =
             convert_coded_term_mapping(contributor_mapping, image)
           descriptive_metadata['subject'] =

--- a/spec/services/donut/migration_service_spec.rb
+++ b/spec/services/donut/migration_service_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Donut::MigrationService do
       ],
       'keyword' => %w[keyword_1],
       'rights_statement' => ['http://rightsstatements.org/vocab/InC-EDU/1.0/'],
-      'date_created' => ['2009-12'],
+      'date_created' => ['2009-12', '202u'],
       'subject' => ['Free text Uncontrolled Subject'],
       'language' => [RDF.URI('http://id.loc.gov/vocabulary/languages/eng')],
       'identifier' => ['OCLC identifier 123'],
@@ -130,7 +130,7 @@ RSpec.describe Donut::MigrationService do
           'preservation_level' => { id: '1', scheme: 'preservation_level' }
         },
         descriptive_metadata: {
-          'date_created' => [{ edtf: '2009-12' }],
+          'date_created' => [{ edtf: '2009-12' }, { edtf: '202X' }],
           'contributor' => [
             {
               role: { id: 'arc', scheme: 'marc_relator' },


### PR DESCRIPTION
Meadow will raise errors during migration because of deprecated EDTF dates that use "u" for unknown such as `202u`. During migration, the dates will be translated to use the current valid "X" character instead.

Note: you can save some time in the tests by just running `bundle exec rspec spec/services/donut/migration_service_spec.rb`